### PR TITLE
Updated cmake version

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,21 +1,14 @@
 
-os:
-  - Visual Studio 2017
+os: Visual Studio 2017
 
 build:
   verbosity: detailed
 
 configuration:
   - Debug
+  - Release
 
-branches:
-  except:
-    - /pr\/.+/
-
-environment:
-  matrix:
-    - BUILD_TESTS: true
-
+init: []
 
 install:
   ############################################################################
@@ -36,7 +29,7 @@ install:
   ############################################################################
   # Install a recent CMake
   ############################################################################
-  - set CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.0-win32-x86.zip"
+  - set CMAKE_URL="https://cmake.org/files/v3.9/cmake-3.9.4-win64-x64.zip"
   - appveyor DownloadFile %CMAKE_URL% -FileName cmake.zip
   - 7z x cmake.zip -oC:\projects\deps\cmake > nul
   - set PATH=C:\projects\deps\cmake\bin;%PATH%
@@ -48,18 +41,24 @@ install:
   - set PATH="C:\Program Files\LLVM\bin";%PATH%
   - clang-cl -v
 
-
-before_build:
-  - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
+  ############################################################################
+  # Download Catch
+  ############################################################################
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\vsdevcmd" -arch=x64
   - set CATCH_DIR=%cd%\catch\include
   - mkdir %CATCH_DIR%
-  - appveyor DownloadFile https://github.com/philsquared/Catch/releases/download/v1.8.1/catch.hpp -FileName %CATCH_DIR%\catch.hpp
-  - cd C:\projects\bit-stl
+  - appveyor DownloadFile https://github.com/philsquared/Catch/releases/download/v1.10.0/catch.hpp -FileName %CATCH_DIR%\catch.hpp
+
+before_build:
+  - cd "C:\projects\bit-stl"
   - git submodule init
   - git submodule update
 
 build_script:
   - mkdir build
   - cd build
-  - cmake .. -GNinja -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_INCLUDE_PATH=%CATCH_DIR% -DCMAKE_CXX_FLAGS="-fms-compatibility-version=19 -Wall -Wextra -pedantic" -DBIT_BUILD_TESTS=%BUILD_TESTS%
-  - cmake --build .
+  - cmake .. -G"Ninja" -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_INCLUDE_PATH=%CATCH_DIR% -DCMAKE_CXX_FLAGS="-fms-compatibility-version=19 -Wall -Wextra -pedantic"  -DBIT_STL_COMPILE_UNIT_TESTS=On -DBIT_STL_COMPILE_HEADER_SELF_CONTAINMENT_TESTS=On
+  - cmake --build . --config %CONFIGURATION%
+
+test_script:
+  - cmake --build . --target test

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,27 +20,6 @@ matrix:
       env:
         - TOOLSET=g++-6 BUILD_TYPE='Release'
 
-    # Linux clang-3.8
-    # Clang on linux is demoporarily disabled, since
-
-    # std::make_reverse_iterator fails to work
-    # - os: linux
-    #   compiler: clang
-    #   addons:
-    #     apt:
-    #       sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.8' ]
-    #       packages: [ 'clang-3.8' ]
-    #   env:
-    #     - TOOLSET=clang++-3.8 BUILD_TYPE='Debug' CXX_FLAGS=-stdlib=libstdc++
-    # - os: linux
-    #   compiler: clang
-    #   addons:
-    #     apt:
-    #       sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.8' ]
-    #       packages: [ 'clang-3.8' ]
-    #   env:
-    #     - TOOLSET=clang++-3.8 BUILD_TYPE='Release' CXX_FLAGS=-stdlib=libstdc++
-
     # OSX clang
     - os: osx
       compiler: clang
@@ -54,16 +33,18 @@ install:
 
   # Get dependency 'catch'
   - mkdir -p catch/include
-  - wget https://github.com/philsquared/Catch/releases/download/v1.8.1/catch.hpp -P catch/include
+  - wget https://github.com/philsquared/Catch/releases/download/v1.10.0/catch.hpp -P catch/include
   - export CATCH_DIR=$(pwd)/catch/include
 
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget --no-check-certificate https://www.cmake.org/files/v3.3/cmake-3.3.1-Linux-x86_64.tar.gz; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar -xzf cmake-3.3.1-Linux-x86_64.tar.gz; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CMAKE=$TRAVIS_BUILD_DIR/../cmake-3.3.1-Linux-x86_64/bin/cmake; fi
+  # Install cmake 3.9.4 for Linux
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget --no-check-certificate https://www.cmake.org/files/v3.9/cmake-3.9.4-Linux-x86_64.tar.gz; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar -xzf cmake-3.9.4-Linux-x86_64.tar.gz; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CMAKE=$TRAVIS_BUILD_DIR/../cmake-3.9.4-Linux-x86_64/bin/cmake; fi
 
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then wget --no-check-certificate https://cmake.org/files/v3.3/cmake-3.3.0-Darwin-x86_64.tar.gz; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then tar -xzf cmake-3.3.0-Darwin-x86_64.tar.gz && ls && ls cmake-3.3.0-Darwin-x86_64; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CMAKE=$TRAVIS_BUILD_DIR/../cmake-3.3.0-Darwin-x86_64/CMake.app/Contents/bin/cmake; fi
+  # Install cmake 3.9.4 for MacOS
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then wget --no-check-certificate https://cmake.org/files/v3.9/cmake-3.9.4-Darwin-x86_64.tar.gz; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then tar -xzf cmake-3.9.4-Darwin-x86_64.tar.gz && ls && ls cmake-3.9.4-Darwin-x86_64; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CMAKE=$TRAVIS_BUILD_DIR/../cmake-3.9.4-Darwin-x86_64/CMake.app/Contents/bin/cmake; fi
 
   - export CXX=$TOOLSET
   - $CXX --version
@@ -73,7 +54,7 @@ install:
 
 script:
   - mkdir build/ && cd build/
-  - echo $CMAKE .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INCLUDE_PATH=$CATCH_DIR -DCMAKE_CXX_FLAGS="-Wall -Wextra -pedantic $CXX_FLAGS" -DBIT_STL_COMPILE_UNIT_TESTS=On
-  - $CMAKE .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INCLUDE_PATH=$CATCH_DIR -DCMAKE_CXX_FLAGS="-Wall -Wextra -pedantic $CXX_FLAGS" -DBIT_STL_COMPILE_UNIT_TESTS=On
+  - $CMAKE .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INCLUDE_PATH=$CATCH_DIR -DCMAKE_CXX_FLAGS="-Wall -Wextra -pedantic $CXX_FLAGS" -DBIT_STL_COMPILE_UNIT_TESTS=On -DBIT_STL_COMPILE_HEADER_SELF_CONTAINMENT_TESTS=On
   - $CMAKE --build .
+  - export CTEST_OUTPUT_ON_FAILURE=1
   - $CMAKE --build . --target test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules")
 
 include(AddHeaderSelfContainmentTest)
 include(MakeVersionHeader)
-include(EnableCcache)
+include(EnableCCache)
 
 #-----------------------------------------------------------------------------
 # Project Setup

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,9 @@ enable_testing()
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules")
 
-include(AddIndependenceCheck)
+include(AddHeaderSelfContainmentTest)
 include(MakeVersionHeader)
-include(EnableCCache)
+include(EnableCcache)
 
 #-----------------------------------------------------------------------------
 # Project Setup
@@ -15,8 +15,8 @@ include(EnableCCache)
 # enable cacche to speed up compilations
 enable_ccache()
 
-option(BIT_STL_COMPILE_INDEPENDENCE_TESTS "Include each header independently in a .cpp file to determine header independence" on)
-option(BIT_STL_COMPILE_UNIT_TESTS "Compile and run the unit tests for this library" on)
+option(BIT_STL_COMPILE_HEADER_SELF_CONTAINMENT_TESTS "Include each header independently in a .cpp file to determine header self-containment" off)
+option(BIT_STL_COMPILE_UNIT_TESTS "Compile and run the unit tests for this library" off)
 option(BIT_STL_GENERATE_DOCUMENTATION "Generates doxygen documentation" off)
 
 project("BitStl")
@@ -54,51 +54,53 @@ make_version_header("${CMAKE_CURRENT_BINARY_DIR}/include/bit/stl/version.hpp"
 )
 
 set(headers
-      include/bit/stl/array.hpp
-      include/bit/stl/array_view.hpp
-      include/bit/stl/assert.hpp
-      include/bit/stl/casts.hpp
-      include/bit/stl/checked.hpp
-      include/bit/stl/circular_array.hpp
-      include/bit/stl/circular_buffer.hpp
-      include/bit/stl/circular_deque.hpp
-      include/bit/stl/circular_queue.hpp
-      include/bit/stl/data_watcher.hpp
-      include/bit/stl/delegate.hpp
-      include/bit/stl/enum.hpp
-      include/bit/stl/expected.hpp
-      include/bit/stl/functional.hpp
-      include/bit/stl/hashed_string.hpp
-      include/bit/stl/hashed_string_view.hpp
-      include/bit/stl/iterator.hpp
-      include/bit/stl/lazy.hpp
-      include/bit/stl/map_view.hpp
-      include/bit/stl/memory.hpp
-      include/bit/stl/numeric.hpp
-      include/bit/stl/optional.hpp
-      include/bit/stl/pointer_wrapper.hpp
-      include/bit/stl/range.hpp
-      include/bit/stl/set_view.hpp
-      include/bit/stl/source_location.hpp
-      include/bit/stl/span.hpp
-      include/bit/stl/stddef.hpp
-      include/bit/stl/string.hpp
-      include/bit/stl/string_span.hpp
-      include/bit/stl/string_tokenizer.hpp
-      include/bit/stl/string_view.hpp
-      include/bit/stl/tribool.hpp
-      include/bit/stl/tuple.hpp
-      include/bit/stl/type_traits.hpp
-      include/bit/stl/utility.hpp
-      include/bit/stl/uuid.hpp
+  include/bit/stl/array.hpp
+  include/bit/stl/array_view.hpp
+  include/bit/stl/assert.hpp
+  include/bit/stl/casts.hpp
+  include/bit/stl/checked.hpp
+  include/bit/stl/circular_array.hpp
+  include/bit/stl/circular_buffer.hpp
+  include/bit/stl/circular_deque.hpp
+  include/bit/stl/circular_queue.hpp
+  include/bit/stl/data_watcher.hpp
+  include/bit/stl/delegate.hpp
+  include/bit/stl/enum.hpp
+  include/bit/stl/expected.hpp
+  include/bit/stl/functional.hpp
+  include/bit/stl/hashed_string.hpp
+  include/bit/stl/hashed_string_view.hpp
+  include/bit/stl/iterator.hpp
+  include/bit/stl/lazy.hpp
+  include/bit/stl/map_view.hpp
+  include/bit/stl/memory.hpp
+  include/bit/stl/numeric.hpp
+  include/bit/stl/optional.hpp
+  include/bit/stl/pointer_wrapper.hpp
+  include/bit/stl/range.hpp
+  include/bit/stl/set_view.hpp
+  include/bit/stl/source_location.hpp
+  include/bit/stl/span.hpp
+  include/bit/stl/stddef.hpp
+  include/bit/stl/string.hpp
+  include/bit/stl/string_span.hpp
+  include/bit/stl/string_tokenizer.hpp
+  include/bit/stl/string_view.hpp
+  include/bit/stl/tribool.hpp
+  include/bit/stl/tuple.hpp
+  include/bit/stl/type_traits.hpp
+  include/bit/stl/utility.hpp
+  include/bit/stl/uuid.hpp
 )
 
-add_library(stl INTERFACE)
-add_library(bit::stl ALIAS stl)
+add_library(bit_stl INTERFACE)
+add_library(bit::stl ALIAS bit_stl)
 
-target_include_directories(stl INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
-                                         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
-target_compile_definitions(stl INTERFACE
+target_include_directories(bit_stl INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+)
+target_compile_definitions(bit_stl INTERFACE
   $<$<CONFIG:DEBUG>:DEBUG>
   $<$<CONFIG:RELEASE>:DEBUG RELEASE>
 )
@@ -107,24 +109,24 @@ target_compile_definitions(stl INTERFACE
 # bit::stl : Independence Tests
 #-----------------------------------------------------------------------------
 
-if( BIT_STL_COMPILE_INDEPENDENCE_TESTS )
+if( BIT_STL_COMPILE_HEADER_SELF_CONTAINMENT_TESTS )
 
-  add_independence_check(stl_independence ${headers})
+  # Add containment test and alias as 'bit::stl::header_self_containment_test'
+  add_header_self_containment_test(bit_stl_header_self_containment_test ${headers})
+  add_library(bit::stl::header_self_containment_test ALIAS bit_stl_header_self_containment_test)
 
-  target_compile_definitions(stl_independence PRIVATE
+  target_compile_definitions(bit_stl_header_self_containment_test PRIVATE
     $<$<CONFIG:DEBUG>:DEBUG>
-    $<$<CONFIG:RELEASE>:DEBUG RELEASE>
+    $<$<CONFIG:RELEASE>:NDEBUG RELEASE>
   )
 
   if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    target_compile_options(stl_independence PRIVATE -Wall -pedantic)
+    target_compile_options(bit_stl_header_self_containment_test PRIVATE -Wall -pedantic)
   elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" )
-    target_compile_options(stl_independence PRIVATE -Wall -pedantic)
+    target_compile_options(bit_stl_header_self_containment_test PRIVATE -Wall -pedantic)
   elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" )
     # TODO: Determine MSVC necessary compiler flags
   endif()
-
-  add_library(bit::stl::independence ALIAS stl_independence)
 
 endif()
 
@@ -154,7 +156,7 @@ if( EXISTS "$ENV{BIT_HOME}" )
   set(CMAKE_INSTALL_PREFIX "$ENV{BIT_HOME}")
 endif()
 
-export_library( TARGETS stl
+export_library( TARGETS bit_stl
                 PACKAGE Stl
                 VERSION ${BIT_STL_VERSION}
                 MAJOR_VERSION ${BIT_STL_VERSION_MAJOR}

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -6,7 +6,7 @@ find_program(CMAKE_DOXYGEN_PROGRAM doxygen)
 set(CMAKE_FIND_APPBUNDLE ${temp_state})
 
 # Add target for generating doxygen
-add_custom_target("bit-stl-doxygen" ALL
+add_custom_target("bit_stl_doxygen" ALL
                   COMMAND "${CMAKE_DOXYGEN_PROGRAM}" "Doxyfile"
                   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
                   COMMENT "Generating Doxygen documentation for 'bit::stl'"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,20 +18,20 @@ set(sources
       bit/stl/utility.compressed_pair.test.cpp
 )
 
-add_executable(stl_test ${sources})
+add_executable(bit_stl_test ${sources})
 
-target_link_libraries(stl_test PRIVATE "bit::stl" "philsquared::Catch")
+target_link_libraries(bit_stl_test PRIVATE "bit::stl" "philsquared::Catch")
 
 #-----------------------------------------------------------------------------
 # Testing
 #-----------------------------------------------------------------------------
 
-add_test( NAME "stl_test_default"
+add_test( NAME "bit_stl_test_default"
           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-          COMMAND "$<TARGET_FILE:stl_test>" )
+          COMMAND "$<TARGET_FILE:bit_stl_test>" )
 
 #-----------------------------------------------------------------------------
 
-add_test( NAME "stl_test_all"
+add_test( NAME "bit_stl_test_all"
           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-          COMMAND "$<TARGET_FILE:stl_test>" "*" )
+          COMMAND "$<TARGET_FILE:bit_stl_test>" "*" )


### PR DESCRIPTION
This updates the CMake submodule, along with a few changes to the `CMakeLists.txt`. Most noteably:

- `stl` now named `bit_stl` to avoid potential conflict. The alias `bit::stl` still exists.
- Independence check now named header self-containment test
- Unit tests no longer build automatically (must be supplied `-DBIT_STL_COMPILE_UNIT_TESTS=On`
- Header self-containment tests no longer build automatically (must be supplied `-DBIT_STL_COMPILE_HEADER_CONTAINMENT_TESTS=On`)

These changes simplify using `bit_stl` as a submodule being included from an `add_subdirectory` call -- rather than requiring an installation through `cmake`. 