### PR TITLE
Feature/expected

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ set(headers
   include/bit/stl/utilities/dynamic_index_constant.hpp
   include/bit/stl/utilities/dynamic_size_constant.hpp
   include/bit/stl/utilities/enum.hpp
+  include/bit/stl/utilities/expected.hpp
   include/bit/stl/utilities/final_act.hpp
   include/bit/stl/utilities/hash.hpp
   include/bit/stl/utilities/in_place.hpp

--- a/include/bit/stl/traits/composition/empty.hpp
+++ b/include/bit/stl/traits/composition/empty.hpp
@@ -13,7 +13,7 @@ namespace bit {
 
     /// \brief Utility metafunction that always expands into an empty struct
     ///        with no members or type members
-    template<typename T>
+    template<typename T = void>
     struct empty{};
 
   } // namespace stl

--- a/include/bit/stl/utilities/detail/assert.inl
+++ b/include/bit/stl/utilities/detail/assert.inl
@@ -35,10 +35,10 @@ inline void bit::stl::default_assert( const char* message,
                                       source_location source )
 {
   std::fprintf(stderr, "[assertion] %s (%zu)::%s\n"
-                       "            %s", source.file_name(),
-                                         source.line(),
-                                         source.function_name(),
-                                         message );
+                       "            %s\n", source.file_name(),
+                                           source.line(),
+                                           source.function_name(),
+                                           message );
 
   BIT_BREAKPOINT();
 }

--- a/include/bit/stl/utilities/detail/expected.inl
+++ b/include/bit/stl/utilities/detail/expected.inl
@@ -1130,4 +1130,262 @@ inline constexpr const bit::stl::unexpected_type<E>&&
   return std::move(base_type::get_unexpected());
 }
 
+//=============================================================================
+// X.Z.8, Expected relational operators
+//=============================================================================
+
+template<typename T, typename E>
+inline constexpr bool
+  bit::stl::operator==( const expected<T,E>& lhs, const expected<T,E>& rhs )
+{
+  return lhs.has_value() != rhs.has_value() ? false :
+         lhs.has_error() ? lhs.get_unexpected() == rhs.get_unexpected() :
+         lhs.has_value() ? *lhs == *rhs : true;
+}
+
+template<typename T, typename E>
+inline constexpr bool
+  bit::stl::operator!=( const expected<T,E>& lhs, const expected<T,E>& rhs )
+{
+  return lhs.has_value() != rhs.has_value() ? true :
+         lhs.has_error() ? lhs.get_unexpected() != rhs.get_unexpected() :
+         lhs.has_value() ? *lhs != *rhs : false;
+}
+
+template<typename T, typename E>
+inline constexpr bool
+  bit::stl::operator<( const expected<T,E>& lhs, const expected<T,E>& rhs )
+{
+  return lhs.has_value() && rhs.has_value() ? *lhs < *rhs :
+         lhs.has_error() && rhs.has_error() ? lhs.get_unexpected() < rhs.get_unexpected() :
+         lhs.has_value() && !rhs.has_value() ? true :
+        !lhs.has_value() && rhs.has_value() ? false :
+         lhs.valueless_by_exception() && rhs.valueless_by_exception() ? false :
+         false;
+}
+
+template<typename T, typename E>
+inline constexpr bool
+  bit::stl::operator>( const expected<T,E>& lhs, const expected<T,E>& rhs )
+{
+  return lhs.has_value() && rhs.has_value() ? *lhs > *rhs :
+         lhs.has_error() && rhs.has_error() ? lhs.get_unexpected() > rhs.get_unexpected() :
+         lhs.has_value() && !rhs.has_value() ? false :
+        !lhs.has_value() && rhs.has_value() ? true :
+         lhs.valueless_by_exception() && rhs.valueless_by_exception() ? false :
+         false;
+}
+
+template<typename T, typename E>
+inline constexpr bool
+  bit::stl::operator<=( const expected<T,E>& lhs, const expected<T,E>& rhs )
+{
+  return lhs.has_value() && rhs.has_value() ? *lhs <= *rhs :
+         lhs.has_error() && rhs.has_error() ? lhs.get_unexpected() <= rhs.get_unexpected() :
+         lhs.has_value() && !rhs.has_value() ? true :
+        !lhs.has_value() && rhs.has_value() ? false :
+         lhs.valueless_by_exception() && rhs.valueless_by_exception() ? true :
+         false;
+}
+
+template<typename T, typename E>
+inline constexpr bool
+  bit::stl::operator>=( const expected<T,E>& lhs, const expected<T,E>& rhs )
+{
+  return lhs.has_value() && rhs.has_value() ? *lhs >= *rhs :
+         lhs.has_error() && rhs.has_error() ? lhs.get_unexpected() >= rhs.get_unexpected() :
+         lhs.has_value() && !rhs.has_value() ? false :
+        !lhs.has_value() && rhs.has_value() ? true :
+         lhs.valueless_by_exception() && rhs.valueless_by_exception() ? true :
+         false;
+
+}
+
+//=============================================================================
+// X.Z.9, Comparison with T
+//=============================================================================
+
+template<typename T, typename E>
+inline constexpr bool
+  bit::stl::operator==( const expected<T,E>& x, const T& v )
+{
+  return static_cast<bool>(x) ? *x == v : false;
+}
+
+template<typename T, typename E>
+inline constexpr bool
+  bit::stl::operator==( const T& v, const expected<T,E>& x )
+{
+  return static_cast<bool>(x) ? v == *x : false;
+}
+
+template<typename T, typename E>
+inline constexpr bool
+  bit::stl::operator!=( const expected<T,E>& x, const T& v )
+{
+  return static_cast<bool>(x) ? *x != v : true;
+}
+
+template<typename T, typename E>
+inline constexpr bool
+  bit::stl::operator!=( const T& v, const expected<T,E>& x )
+{
+  return static_cast<bool>(x) ? v != *x : true;
+}
+
+template<typename T, typename E>
+inline constexpr bool
+  bit::stl::operator<( const expected<T,E>& x, const T& v )
+{
+  return static_cast<bool>(x) ? *x < v : false;
+}
+
+template<typename T, typename E>
+inline constexpr bool
+  bit::stl::operator<( const T& v, const expected<T,E>& x )
+{
+  return static_cast<bool>(x) ? v < *x : true;
+}
+
+template<typename T, typename E>
+inline constexpr bool
+  bit::stl::operator<=( const expected<T,E>& x, const T& v )
+{
+  return static_cast<bool>(x) ? *x <= v : false;
+}
+
+template<typename T, typename E>
+inline constexpr bool
+  bit::stl::operator<=( const T& v, const expected<T,E>& x )
+{
+  return static_cast<bool>(x) ? v <= *x : true;
+}
+
+template<typename T, typename E>
+inline constexpr bool
+  bit::stl::operator>( const expected<T,E>& x, const T& v )
+{
+  return static_cast<bool>(x) ? *x > v : true;
+}
+
+template<typename T, typename E>
+inline constexpr bool
+  bit::stl::operator>( const T& v, const expected<T,E>& x )
+{
+  return static_cast<bool>(x) ? v > *x : false;
+}
+
+template<typename T, typename E>
+inline constexpr bool
+  bit::stl::operator>=( const expected<T,E>& x, const T& v )
+{
+  return static_cast<bool>(x) ? *x >= v : true;
+}
+
+template<typename T, typename E>
+inline constexpr bool
+  bit::stl::operator>=( const T& v, const expected<T,E>& x )
+{
+  return static_cast<bool>(x) ? v >= *x : false;
+}
+
+//=============================================================================
+// X.Z.10, Comparison with unexpected_type<E>
+//=============================================================================
+
+template<typename T, typename E>
+inline constexpr bool bit::stl::operator==( const expected<T,E>& x,
+                                            const unexpected_type<E>& e )
+{
+  return static_cast<bool>(x) ? true : x.get_unexpected() == e;
+}
+
+template<typename T, typename E>
+inline constexpr bool bit::stl::operator==( const unexpected_type<E>& e,
+                                            const expected<T,E>& x )
+{
+  return static_cast<bool>(x) ? true : e== x.get_unexpected();
+}
+
+template<typename T, typename E>
+inline constexpr bool bit::stl::operator!=( const expected<T,E>& x,
+                                            const unexpected_type<E>& e)
+{
+  return static_cast<bool>(x) ? false : x.get_unexpected() != e;
+}
+
+template<typename T, typename E>
+inline constexpr bool bit::stl::operator!=( const unexpected_type<E>& e,
+                                            const expected<T,E>& x )
+{
+  return static_cast<bool>(x) ? false : e != x.get_unexpected();
+}
+
+template<typename T, typename E>
+inline constexpr bool bit::stl::operator<( const expected<T,E>& x,
+                                           const unexpected_type<E>& e )
+{
+  return static_cast<bool>(x) ? true : x.get_unexpected() < e;
+}
+
+template<typename T, typename E>
+inline constexpr bool bit::stl::operator<( const unexpected_type<E>& e,
+                                           const expected<T,E>& x )
+{
+  return static_cast<bool>(x) ? false : e < x.get_unexpected();
+}
+
+template<typename T, typename E>
+inline constexpr bool bit::stl::operator<=( const expected<T,E>& x,
+                                            const unexpected_type<E>& e )
+{
+  return static_cast<bool>(x) ? true : x.get_unexpected() <= e;
+}
+
+template<typename T, typename E>
+inline constexpr bool bit::stl::operator<=( const unexpected_type<E>& e,
+                                            const expected<T,E>& x )
+{
+  return static_cast<bool>(x) ? false : e <= x.get_unexpected();
+}
+
+template<typename T, typename E>
+inline constexpr bool bit::stl::operator>( const expected<T,E>& x,
+                                           const unexpected_type<E>& e )
+{
+  return static_cast<bool>(x) ? false : x.get_unexpected() > e;
+}
+
+template<typename T, typename E>
+inline constexpr bool bit::stl::operator>( const unexpected_type<E>& e,
+                                           const expected<T,E>& x )
+{
+  return static_cast<bool>(x) ? true : e > x.get_unexpected();
+}
+
+template<typename T, typename E>
+inline constexpr bool bit::stl::operator>=( const expected<T,E>& x,
+                                            const unexpected_type<E>& e )
+{
+  return static_cast<bool>(x) ? false : x.get_unexpected() >= e;
+}
+
+template<typename T, typename E>
+inline constexpr bool bit::stl::operator>=( const unexpected_type<E>& e,
+                                            const expected<T,E>& x )
+{
+  return static_cast<bool>(x) ? true : e >= x.get_unexpected();
+}
+
+//-----------------------------------------------------------------------------
+
+// X.Z.11, Specialized algorithms
+
+template<typename T, typename E>
+inline void bit::stl::swap( expected<T,E>& lhs, expected<T,E>& rhs )
+{
+  lhs.swap(rhs);
+}
+
+
 #endif /* BIT_STL_UTILITIES_DETAIL_EXPECTED_INL */

--- a/include/bit/stl/utilities/detail/expected.inl
+++ b/include/bit/stl/utilities/detail/expected.inl
@@ -233,7 +233,7 @@ inline constexpr bit::stl::detail::expected_base<true,T,E>::expected_base()
 
 template<typename T, typename E>
 template<typename...Args>
-  inline constexpr bit::stl::detail::expected_base<true,T,E>
+inline constexpr bit::stl::detail::expected_base<true,T,E>
   ::expected_base( in_place_t, Args&&...args )
   : m_storage( in_place, std::forward<Args>(args)... ),
     m_has_value(true)
@@ -360,6 +360,7 @@ inline void bit::stl::detail::expected_base<true,T,E>
   try {
 #endif // BIT_COMPILER_EXCEPTIONS_ENABLED
     new (&m_storage.value) T( std::forward<Args>(args)... );
+    m_has_value = true;
 #if BIT_COMPILER_EXCEPTIONS_ENABLED
   } catch( ... ) {
     m_has_value = indeterminate;
@@ -376,7 +377,8 @@ inline void bit::stl::detail::expected_base<true,T,E>
 #if BIT_COMPILER_EXCEPTIONS_ENABLED
   try {
 #endif // BIT_COMPILER_EXCEPTIONS_ENABLED
-    new (&m_storage.value) unexpected_type<T>{ std::forward<Args>(args)... };
+    new (&m_storage.error) unexpected_type<E>( std::forward<Args>(args)... );
+    m_has_value = false;
 #if BIT_COMPILER_EXCEPTIONS_ENABLED
   } catch( ... ) {
     m_has_value = indeterminate;
@@ -448,8 +450,7 @@ inline constexpr bit::stl::detail::expected_base<false,T,E>
 //-----------------------------------------------------------------------------
 
 template<typename T, typename E>
-inline bit::stl::detail::expected_base<false,T,E>
-  ::~expected_base()
+inline bit::stl::detail::expected_base<false,T,E>::~expected_base()
 {
   destruct();
 }
@@ -574,6 +575,7 @@ inline void bit::stl::detail::expected_base<false,T,E>
   try {
 #endif // BIT_COMPILER_EXCEPTIONS_ENABLED
     new (&m_storage.value) T{ std::forward<Args>(args)... };
+    m_has_value = true;
 #if BIT_COMPILER_EXCEPTIONS_ENABLED
   } catch( ... ) {
     m_has_value = indeterminate;
@@ -591,7 +593,8 @@ void bit::stl::detail::expected_base<false,T,E>
 #if BIT_COMPILER_EXCEPTIONS_ENABLED
   try {
 #endif // BIT_COMPILER_EXCEPTIONS_ENABLED
-    new (&m_storage.value) unexpected_type<T>{ std::forward<Args>(args)... };
+    new (&m_storage.error) unexpected_type<E>( std::forward<Args>(args)... );
+    m_has_value = false;
 #if BIT_COMPILER_EXCEPTIONS_ENABLED
   } catch( ... ) {
     m_has_value = indeterminate;

--- a/include/bit/stl/utilities/detail/expected.inl
+++ b/include/bit/stl/utilities/detail/expected.inl
@@ -1,0 +1,1133 @@
+#ifndef BIT_STL_UTILITIES_DETAIL_EXPECTED_INL
+#define BIT_STL_UTILITIES_DETAIL_EXPECTED_INL
+
+
+//=============================================================================
+// X.Z.7, class bad_expected_access
+//=============================================================================
+
+//-----------------------------------------------------------------------------
+// Constructors
+//-----------------------------------------------------------------------------
+
+template<typename E>
+bit::stl::bad_expected_access<E>::bad_expected_access( error_type e )
+  : std::logic_error("Found an error instead of the expected value."),
+    m_error_value(std::move(e))
+{
+
+}
+
+//-----------------------------------------------------------------------------
+// Observers
+//-----------------------------------------------------------------------------
+
+template<typename E>
+typename bit::stl::bad_expected_access<E>::error_type&
+  bit::stl::bad_expected_access<E>::error()
+  & noexcept
+{
+  return m_error_value;
+}
+
+template<typename E>
+const typename bit::stl::bad_expected_access<E>::error_type&
+  bit::stl::bad_expected_access<E>::error()
+  const & noexcept
+{
+  return m_error_value;
+}
+
+//-----------------------------------------------------------------------------
+
+template<typename E>
+typename bit::stl::bad_expected_access<E>::error_type&&
+  bit::stl::bad_expected_access<E>::error()
+  && noexcept
+{
+  return std::move(m_error_value);
+}
+
+template<typename E>
+const typename bit::stl::bad_expected_access<E>::error_type&&
+  bit::stl::bad_expected_access<E>::error()
+  const && noexcept
+{
+  return std::move(m_error_value);
+}
+
+//=============================================================================
+
+inline bit::stl::bad_expected_access<void>::bad_expected_access()
+  : std::logic_error("Bad access to expected type with no value.")
+{
+
+}
+
+//=============================================================================
+// X.Y.4, unexpected_type
+//=============================================================================
+
+//-----------------------------------------------------------------------------
+// Constructors
+//-----------------------------------------------------------------------------
+
+template<typename E>
+template<typename E2,typename>
+inline constexpr bit::stl::unexpected_type<E>
+  ::unexpected_type( const unexpected_type<E2>& other )
+  : m_value(other.value())
+{
+
+}
+
+template<typename E>
+template<typename E2,typename>
+inline constexpr bit::stl::unexpected_type<E>
+  ::unexpected_type( unexpected_type<E2>&& other )
+  : m_value(std::move(other.value()))
+{
+
+}
+
+template<typename E>
+inline constexpr bit::stl::unexpected_type<E>
+  ::unexpected_type( const E& other )
+  : m_value(other)
+{
+
+}
+
+template<typename E>
+inline constexpr bit::stl::unexpected_type<E>
+  ::unexpected_type( E&& other )
+  : m_value(std::move(other))
+{
+
+}
+
+template<typename E>
+template<typename...Args, typename>
+inline constexpr bit::stl::unexpected_type<E>
+  ::unexpected_type( in_place_t, Args&&...args )
+  : m_value{ std::forward<Args>(args)... }
+{
+
+}
+
+template<typename E>
+template<typename U, typename...Args, typename>
+inline constexpr bit::stl::unexpected_type<E>
+  ::unexpected_type( in_place_t, std::initializer_list<U> ilist, Args&&...args )
+  : m_value{ std::move(ilist), std::forward<Args>(args)... }
+{
+
+}
+
+//-----------------------------------------------------------------------------
+// Observers
+//-----------------------------------------------------------------------------
+
+template<typename E>
+inline constexpr E& bit::stl::unexpected_type<E>::value()
+  &
+{
+  return m_value;
+}
+
+template<typename E>
+inline constexpr const E& bit::stl::unexpected_type<E>::value()
+  const &
+{
+  return m_value;
+}
+
+//-----------------------------------------------------------------------------
+
+template<typename E>
+inline constexpr E&& bit::stl::unexpected_type<E>::value()
+  &&
+{
+  return std::move(m_value);
+}
+
+template<typename E>
+inline constexpr const E&& bit::stl::unexpected_type<E>::value()
+  const &&
+{
+  return std::move(m_value);
+}
+
+//=============================================================================
+// X.Y.4, Unexpected factories
+//=============================================================================
+
+template<typename E, typename...Args>
+inline constexpr bit::stl::unexpected_type<E>
+  bit::stl::make_unexpected( Args&&...args )
+{
+  return unexpected_type<E>( in_place, std::forward<Args>(args)... );
+}
+
+//=============================================================================
+// X.Y.5, unexpected_type relational operators
+//=============================================================================
+
+template<typename E>
+inline constexpr bool bit::stl::operator==( const unexpected_type<E>& lhs,
+                                            const unexpected_type<E>& rhs )
+{
+  return lhs.value() == rhs.value();
+}
+
+template<typename E>
+inline constexpr bool bit::stl::operator!=( const unexpected_type<E>& lhs,
+                                            const unexpected_type<E>& rhs )
+{
+  return lhs.value() != rhs.value();
+}
+
+template<typename E>
+inline constexpr bool bit::stl::operator<( const unexpected_type<E>& lhs,
+                                           const unexpected_type<E>& rhs )
+{
+  return lhs.value() < rhs.value();
+}
+
+template<typename E>
+inline constexpr bool bit::stl::operator>( const unexpected_type<E>& lhs,
+                                           const unexpected_type<E>& rhs )
+{
+  return lhs.value() > rhs.value();
+}
+
+template<typename E>
+inline constexpr bool bit::stl::operator<=( const unexpected_type<E>& lhs,
+                                            const unexpected_type<E>& rhs )
+{
+  return lhs.value() <= rhs.value();
+}
+
+template<typename E>
+inline constexpr bool bit::stl::operator>=( const unexpected_type<E>& lhs,
+                                            const unexpected_type<E>& rhs )
+{
+  return lhs.value() >= rhs.value();
+}
+
+//=============================================================================
+// detail::expected_base<true,T,E>
+//=============================================================================
+
+//-----------------------------------------------------------------------
+// Constructors
+//-----------------------------------------------------------------------
+
+template<typename T, typename E>
+inline constexpr bit::stl::detail::expected_base<true,T,E>::expected_base()
+  : m_storage(),
+    m_has_value(indeterminate)
+{
+
+}
+
+template<typename T, typename E>
+template<typename...Args>
+  inline constexpr bit::stl::detail::expected_base<true,T,E>
+  ::expected_base( in_place_t, Args&&...args )
+  : m_storage( in_place, std::forward<Args>(args)... ),
+    m_has_value(true)
+{
+
+}
+
+template<typename T, typename E>
+template<typename...Args>
+inline constexpr bit::stl::detail::expected_base<true,T,E>
+  ::expected_base( unexpect_t, Args&&...args )
+  : m_storage( unexpect, std::forward<Args>(args)... ),
+    m_has_value(false)
+{
+
+}
+
+//-----------------------------------------------------------------------------
+// Observers
+//-----------------------------------------------------------------------------
+
+template<typename T, typename E>
+inline constexpr bool bit::stl::detail::expected_base<true,T,E>
+  ::has_value()
+  const noexcept
+{
+  return m_has_value == true;
+}
+
+template<typename T, typename E>
+inline constexpr bool bit::stl::detail::expected_base<true,T,E>
+  ::has_error()
+  const noexcept
+{
+  return m_has_value == false;
+}
+
+template<typename T, typename E>
+inline constexpr bool bit::stl::detail::expected_base<true,T,E>
+  ::valueless_by_exception()
+  const noexcept
+{
+  return m_has_value == indeterminate;
+}
+
+//-----------------------------------------------------------------------------
+
+template<typename T, typename E>
+inline constexpr T&
+  bit::stl::detail::expected_base<true,T,E>::get_value()
+  & noexcept
+{
+  return m_storage.value;
+}
+
+template<typename T, typename E>
+inline constexpr T&&
+  bit::stl::detail::expected_base<true,T,E>::get_value()
+  && noexcept
+{
+  return m_storage.value;
+}
+
+template<typename T, typename E>
+inline constexpr const T&
+  bit::stl::detail::expected_base<true,T,E>::get_value()
+  const & noexcept
+{
+  return m_storage.value;
+}
+
+template<typename T, typename E>
+inline constexpr const T&&
+  bit::stl::detail::expected_base<true,T,E>::get_value()
+  const && noexcept
+{
+  return m_storage.value;
+}
+
+//-----------------------------------------------------------------------------
+
+template<typename T, typename E>
+inline constexpr bit::stl::unexpected_type<E>&
+  bit::stl::detail::expected_base<true,T,E>::get_unexpected()
+  & noexcept
+{
+  return m_storage.error;
+}
+
+template<typename T, typename E>
+inline constexpr  bit::stl::unexpected_type<E>&&
+  bit::stl::detail::expected_base<true,T,E>::get_unexpected()
+  && noexcept
+{
+  return m_storage.error;
+}
+
+template<typename T, typename E>
+inline constexpr const  bit::stl::unexpected_type<E>&
+  bit::stl::detail::expected_base<true,T,E>::get_unexpected()
+  const & noexcept
+{
+  return m_storage.error;
+}
+
+template<typename T, typename E>
+inline constexpr const  bit::stl::unexpected_type<E>&&
+  bit::stl::detail::expected_base<true,T,E>::get_unexpected()
+  const && noexcept
+{
+  return m_storage.error;
+}
+
+//-----------------------------------------------------------------------------
+// Modifiers
+//-----------------------------------------------------------------------------
+
+template<typename T, typename E>
+template<typename...Args>
+inline void bit::stl::detail::expected_base<true,T,E>
+  ::emplace_value( Args&&...args )
+{
+#if BIT_COMPILER_EXCEPTIONS_ENABLED
+  try {
+#endif // BIT_COMPILER_EXCEPTIONS_ENABLED
+    new (&m_storage.value) T( std::forward<Args>(args)... );
+#if BIT_COMPILER_EXCEPTIONS_ENABLED
+  } catch( ... ) {
+    m_has_value = indeterminate;
+    throw;
+  }
+#endif // BIT_COMPILER_EXCEPTIONS_ENABLED
+}
+
+template<typename T, typename E>
+template<typename...Args>
+inline void bit::stl::detail::expected_base<true,T,E>
+  ::emplace_error( Args&&...args )
+{
+#if BIT_COMPILER_EXCEPTIONS_ENABLED
+  try {
+#endif // BIT_COMPILER_EXCEPTIONS_ENABLED
+    new (&m_storage.value) unexpected_type<T>{ std::forward<Args>(args)... };
+#if BIT_COMPILER_EXCEPTIONS_ENABLED
+  } catch( ... ) {
+    m_has_value = indeterminate;
+    throw;
+  }
+#endif // BIT_COMPILER_EXCEPTIONS_ENABLED
+}
+
+//-----------------------------------------------------------------------------
+
+template<typename T, typename E>
+template<typename U>
+inline void bit::stl::detail::expected_base<true,T,E>::assign_value( U&& value )
+{
+  if( m_has_value ) {
+    m_storage.value = std::forward<U>(value);
+  } else {
+    emplace( std::forward<U>(value) );
+  }
+}
+
+template<typename T, typename E>
+template<typename U>
+inline void bit::stl::detail::expected_base<true,T,E>::assign_error( U&& error )
+{
+  if( !m_has_value ) {
+    m_storage.error = std::forward<U>(error);
+  } else {
+    emplace_error( std::forward<U>(error) );
+  }
+}
+
+//=============================================================================
+// detail::expected_base<false,T,E>
+//=============================================================================
+
+//-----------------------------------------------------------------------------
+// Constructors
+//-----------------------------------------------------------------------------
+
+template<typename T, typename E>
+inline constexpr bit::stl::detail::expected_base<false,T,E>::expected_base()
+  : m_storage(),
+    m_has_value(indeterminate)
+{
+
+}
+
+template<typename T, typename E>
+template<typename...Args>
+inline constexpr bit::stl::detail::expected_base<false,T,E>
+  ::expected_base( in_place_t, Args&&...args )
+  : m_storage( in_place, std::forward<Args>(args)... ),
+    m_has_value(true)
+{
+
+}
+
+template<typename T, typename E>
+template<typename...Args>
+inline constexpr bit::stl::detail::expected_base<false,T,E>
+  ::expected_base( unexpect_t, Args&&...args )
+  : m_storage( unexpect, std::forward<Args>(args)... ),
+    m_has_value(false)
+{
+
+}
+
+//-----------------------------------------------------------------------------
+
+template<typename T, typename E>
+inline bit::stl::detail::expected_base<false,T,E>
+  ::~expected_base()
+{
+  destruct();
+}
+
+//-----------------------------------------------------------------------------
+// Observers
+//-----------------------------------------------------------------------------
+
+template<typename T, typename E>
+inline constexpr bool bit::stl::detail::expected_base<false,T,E>::has_value()
+  const noexcept
+{
+  return m_has_value == true;
+}
+
+template<typename T, typename E>
+constexpr bool bit::stl::detail::expected_base<false,T,E>::has_error()
+  const noexcept
+{
+  return m_has_value == false;
+}
+
+template<typename T, typename E>
+constexpr bool bit::stl::detail::expected_base<false,T,E>
+  ::valueless_by_exception()
+  const noexcept
+{
+  return m_has_value == indeterminate;
+}
+
+//-----------------------------------------------------------------------------
+
+template<typename T, typename E>
+inline constexpr T&
+  bit::stl::detail::expected_base<false,T,E>::get_value()
+  & noexcept
+{
+  return m_storage.value;
+}
+
+template<typename T, typename E>
+inline constexpr T&&
+  bit::stl::detail::expected_base<false,T,E>::get_value()
+  && noexcept
+{
+  return m_storage.value;
+}
+
+template<typename T, typename E>
+inline constexpr const T&
+  bit::stl::detail::expected_base<false,T,E>::get_value()
+  const & noexcept
+{
+  return m_storage.value;
+}
+
+template<typename T, typename E>
+inline constexpr const T&&
+  bit::stl::detail::expected_base<false,T,E>::get_value()
+  const && noexcept
+{
+  return m_storage.value;
+}
+
+//-----------------------------------------------------------------------------
+
+template<typename T, typename E>
+inline constexpr bit::stl::unexpected_type<E>&
+  bit::stl::detail::expected_base<false,T,E>::get_unexpected()
+  & noexcept
+{
+  return m_storage.error;
+}
+
+template<typename T, typename E>
+inline constexpr  bit::stl::unexpected_type<E>&&
+  bit::stl::detail::expected_base<false,T,E>::get_unexpected()
+  && noexcept
+{
+  return m_storage.error;
+}
+
+template<typename T, typename E>
+inline constexpr const  bit::stl::unexpected_type<E>&
+  bit::stl::detail::expected_base<false,T,E>::get_unexpected()
+  const & noexcept
+{
+  return m_storage.error;
+}
+
+template<typename T, typename E>
+inline constexpr const  bit::stl::unexpected_type<E>&&
+  bit::stl::detail::expected_base<false,T,E>::get_unexpected()
+  const && noexcept
+{
+  return m_storage.error;
+}
+
+//-----------------------------------------------------------------------------
+// Modifiers
+//-----------------------------------------------------------------------------
+
+template<typename T, typename E>
+inline void bit::stl::detail::expected_base<false,T,E>::destruct()
+{
+  if( m_has_value ) {
+    m_storage.value.~T();
+  } else if( !m_has_value ) {
+    m_storage.error.~E();
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+template<typename T, typename E>
+template<typename...Args>
+inline void bit::stl::detail::expected_base<false,T,E>
+  ::emplace_value( Args&&...args )
+{
+  destruct();
+#if BIT_COMPILER_EXCEPTIONS_ENABLED
+  try {
+#endif // BIT_COMPILER_EXCEPTIONS_ENABLED
+    new (&m_storage.value) T{ std::forward<Args>(args)... };
+#if BIT_COMPILER_EXCEPTIONS_ENABLED
+  } catch( ... ) {
+    m_has_value = indeterminate;
+    throw;
+  }
+#endif // BIT_COMPILER_EXCEPTIONS_ENABLED
+}
+
+template<typename T, typename E>
+template<typename...Args>
+void bit::stl::detail::expected_base<false,T,E>
+  ::emplace_error( Args&&...args )
+{
+  destruct();
+#if BIT_COMPILER_EXCEPTIONS_ENABLED
+  try {
+#endif // BIT_COMPILER_EXCEPTIONS_ENABLED
+    new (&m_storage.value) unexpected_type<T>{ std::forward<Args>(args)... };
+#if BIT_COMPILER_EXCEPTIONS_ENABLED
+  } catch( ... ) {
+    m_has_value = indeterminate;
+    throw;
+  }
+#endif // BIT_COMPILER_EXCEPTIONS_ENABLED
+}
+
+//-----------------------------------------------------------------------------
+
+template<typename T, typename E>
+template<typename U>
+inline void bit::stl::detail::expected_base<false,T,E>
+::assign_value( U&& value )
+{
+  if( !m_has_value ) {
+    m_storage.value = std::forward<U>(value);
+  } else {
+    emplace( std::forward<U>(value) );
+  }
+}
+
+template<typename T, typename E>
+template<typename U>
+inline void bit::stl::detail::expected_base<false,T,E>
+  ::assign_error( U&& error )
+{
+  if( m_has_value ) {
+    m_storage.error = std::forward<U>(error);
+  } else {
+    emplace_error( std::forward<U>(error) );
+  }
+}
+
+//=============================================================================
+// expected<T,E>
+//=============================================================================
+
+//-----------------------------------------------------------------------------
+// Constructor
+//-----------------------------------------------------------------------------
+
+template<typename T, typename E>
+template<typename U, typename>
+inline constexpr bit::stl::expected<T,E>::expected()
+  : base_type( in_place )
+{
+
+}
+
+//-----------------------------------------------------------------------------
+
+template<typename T, typename E>
+inline bit::stl::expected<T,E>
+  ::expected( enable_overload_if<std::is_copy_constructible<T>::value &&
+                                 std::is_copy_constructible<E>::value,
+                                 const expected&> other )
+  : base_type()
+{
+  if( other.has_value() ) {
+    base_type::emplace_value( other.get_value() );
+  } else if ( other.has_error() ) {
+    base_type::emplace_error( other.get_unexpected() );
+  }
+}
+
+template<typename T, typename E>
+inline bit::stl::expected<T,E>
+  ::expected( enable_overload_if<std::is_move_constructible<T>::value &&
+                                 std::is_move_constructible<E>::value,
+                                 expected&&> other )
+  : base_type()
+{
+  if( other.has_value() ) {
+    base_type::emplace_value( std::move(other.get_value()) );
+  } else if ( other.has_error() ) {
+    base_type::emplace_error( std::move(other.get_unexpected()) );
+  }
+}
+
+//-----------------------------------------------------------------------
+
+template<typename T, typename E>
+template<typename U, typename G, typename>
+inline bit::stl::expected<T,E>::expected( const expected<U,G>& other )
+  : base_type()
+{
+  if( other.has_value() ) {
+    base_type::emplace_value( other.get_value() );
+  } else if ( other.has_error() ) {
+    base_type::emplace_error( other.get_unexpected() );
+  }
+}
+
+template<typename T, typename E>
+template<typename U, typename G, typename>
+inline bit::stl::expected<T,E>::expected( expected<U,G>&& other )
+  : base_type()
+{
+  if( other.has_value() ) {
+    base_type::emplace_value( std::move(other.get_value()) );
+  } else if ( other.has_error() ) {
+    base_type::emplace_error( std::move(other.get_unexpected()) );
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+template<typename T, typename E>
+template<typename U, typename>
+inline constexpr bit::stl::expected<T,E>::expected( const T& value )
+  : base_type( in_place, value )
+{
+
+}
+
+template<typename T, typename E>
+template<typename U, typename>
+constexpr bit::stl::expected<T,E>::expected( T&& value )
+  : base_type( in_place, std::forward<T>(value) )
+{
+
+}
+
+//-----------------------------------------------------------------------------
+
+template<typename T, typename E>
+template<typename...Args, typename>
+inline constexpr bit::stl::expected<T,E>
+  ::expected( in_place_t, Args&&...args )
+  : base_type( in_place, std::forward<Args>(args)... )
+{
+
+}
+
+template<typename T, typename E>
+template<typename U, typename...Args, typename>
+inline constexpr bit::stl::expected<T,E>
+  ::expected( in_place_t, std::initializer_list<U> ilist, Args&&...args )
+  : base_type( in_place, std::move(ilist), std::forward<Args>(args)... )
+{
+
+}
+
+//-----------------------------------------------------------------------------
+
+template<typename T, typename E>
+template<typename UError, typename>
+inline constexpr bit::stl::expected<T,E>
+  ::expected( unexpected_type<E> const& unexpected )
+  : base_type( unexpect, unexpected.value() )
+{
+
+}
+
+template<typename T, typename E>
+template<typename Err, typename>
+inline constexpr bit::stl::expected<T,E>
+  ::expected( unexpected_type<Err> const& unexpected )
+  : base_type( unexpect, unexpected.value() )
+{
+
+}
+
+//-----------------------------------------------------------------------------
+
+template<typename T, typename E>
+template<typename...Args, typename>
+inline constexpr bit::stl::expected<T,E>
+  ::expected( unexpect_t, Args&&...args )
+  : base_type( unexpect, std::forward<Args>(args)... )
+{
+
+}
+
+template<typename T, typename E>
+template<typename U, typename...Args, typename>
+inline constexpr bit::stl::expected<T,E>
+  ::expected( unexpect_t, std::initializer_list<U> ilist, Args&&...args )
+  : base_type( unexpect, std::move(ilist), std::forward<Args>(args)... )
+{
+
+}
+
+//-----------------------------------------------------------------------------
+
+template<typename T, typename E>
+template<typename U, typename F, typename>
+inline bit::stl::expected<T,E>& bit::stl::expected<T,E>
+  ::operator=( const expected& other )
+{
+  if( other.has_value() ) {
+    base_type::assign_value(other.get_value());
+  } else if( other.has_error() ) {
+    base_type::assign_error(other.get_unexpected());
+  }
+
+  return (*this);
+}
+
+template<typename T, typename E>
+template<typename U, typename F, typename>
+inline bit::stl::expected<T,E>& bit::stl::expected<T,E>
+  ::operator=( expected&& other )
+{
+  if( other.has_value() ) {
+    base_type::assign_value( std::move(other.get_value()) );
+  } else if( other.has_error() ) {
+    base_type::assign_error( std::move(other.get_unexpected()) );
+  }
+
+  return (*this);
+}
+
+template<typename T, typename E>
+template<typename U,typename>
+inline bit::stl::expected<T,E>&
+  bit::stl::expected<T,E>::operator=( U&& value )
+{
+  base_type::assign_value( std::forward<U>(value) );
+
+  return (*this);
+}
+
+template<typename T, typename E>
+inline bit::stl::expected<T,E>&
+  bit::stl::expected<T,E>::operator=( const unexpected_type<E>& unexpected )
+{
+  base_type::assign_error( unexpected.value() );
+
+  return (*this);
+}
+
+template<typename T, typename E>
+inline bit::stl::expected<T,E>&
+  bit::stl::expected<T,E>::operator=( unexpected_type<E>&& unexpected )
+{
+  base_type::assign_error( std::move(unexpected.value()) );
+
+  return (*this);
+}
+
+//-----------------------------------------------------------------------------
+// Modifiers
+//-----------------------------------------------------------------------------
+
+template<typename T, typename E>
+template<typename...Args, typename>
+inline void bit::stl::expected<T,E>::emplace( Args&&...args )
+{
+  base_type::emplace_value( std::forward<Args>(args)... );
+}
+
+template<typename T, typename E>
+template<typename U, typename...Args, typename>
+inline void bit::stl::expected<T,E>::emplace( std::initializer_list<U> ilist,
+                                              Args&&...args )
+{
+  base_type::emplace_value( std::move(ilist), std::forward<Args>(args)... );
+}
+
+template<typename T, typename E>
+inline void bit::stl::expected<T,E>::swap( expected& other )
+{
+
+}
+
+//-----------------------------------------------------------------------------
+// Observers
+//-----------------------------------------------------------------------------
+
+template<typename T, typename E>
+inline constexpr bool bit::stl::expected<T,E>::has_value()
+  const noexcept
+{
+  return base_type::has_value();
+}
+
+template<typename T, typename E>
+inline constexpr bool bit::stl::expected<T,E>::has_error()
+  const noexcept
+{
+  return base_type::has_error();
+}
+
+template<typename T, typename E>
+inline constexpr bool bit::stl::expected<T,E>::valueless_by_exception()
+  const noexcept
+{
+  return base_type::valueless_by_exception();
+}
+
+template<typename T, typename E>
+inline constexpr bit::stl::expected<T,E>::operator bool()
+  const noexcept
+{
+  return has_value();
+}
+
+//-----------------------------------------------------------------------------
+
+template<typename T, typename E>
+inline constexpr T* bit::stl::expected<T,E>::operator->()
+{
+  return &base_type::get_value();
+}
+
+template<typename T, typename E>
+inline constexpr const T* bit::stl::expected<T,E>::operator->()
+  const
+{
+  return &base_type::get_value();
+}
+
+template<typename T, typename E>
+inline constexpr T& bit::stl::expected<T,E>::operator*()
+  &
+{
+  return base_type::get_value();
+}
+
+template<typename T, typename E>
+inline constexpr T&& bit::stl::expected<T,E>::operator*()
+  &&
+{
+  return base_type::get_value();
+}
+
+template<typename T, typename E>
+inline constexpr const T& bit::stl::expected<T,E>::operator*()
+  const &
+{
+  return base_type::get_value();
+}
+
+template<typename T, typename E>
+inline constexpr const T&& bit::stl::expected<T,E>::operator*()
+  const &&
+{
+  return base_type::get_value();
+}
+
+//-----------------------------------------------------------------------------
+
+template<typename T, typename E>
+inline constexpr T& bit::stl::expected<T,E>::value()
+  &
+{
+#if BIT_COMPILER_EXCEPTIONS_ENABLED
+  if( has_error() ) {
+    throw bad_expected_access<E>( base_type::get_unexpected().value() );
+  } else if ( valueless_by_exception() ) {
+    throw bad_expected_access<void>();
+  }
+#else
+  BIT_ALWAYS_ASSERT( has_value(), "expected must have value" );
+#endif
+  return base_type::get_value();
+}
+
+template<typename T, typename E>
+inline constexpr T&& bit::stl::expected<T,E>::value()
+  &&
+{
+#if BIT_COMPILER_EXCEPTIONS_ENABLED
+  if( has_error() ) {
+    throw bad_expected_access<E>( base_type::get_unexpected().value() );
+  } else if ( valueless_by_exception() ) {
+    throw bad_expected_access<void>();
+  }
+#else
+  BIT_ALWAYS_ASSERT( has_value(), "expected must have value" );
+#endif
+  return std::move(base_type::get_value());
+}
+
+template<typename T, typename E>
+inline constexpr const T& bit::stl::expected<T,E>::value()
+  const &
+{
+#if BIT_COMPILER_EXCEPTIONS_ENABLED
+  if( has_error() ) {
+    throw bad_expected_access<E>( base_type::get_unexpected().value() );
+  } else if ( valueless_by_exception() ) {
+    throw bad_expected_access<void>();
+  }
+#else
+  BIT_ALWAYS_ASSERT( has_value(), "expected must have value" );
+#endif
+  return base_type::get_value();
+}
+
+template<typename T, typename E>
+inline constexpr const T&& bit::stl::expected<T,E>::value()
+  const &&
+{
+#if BIT_COMPILER_EXCEPTIONS_ENABLED
+  if( has_error() ) {
+    throw bad_expected_access<E>( base_type::get_unexpected().value() );
+  } else if ( valueless_by_exception() ) {
+    throw bad_expected_access<void>();
+  }
+#else
+  BIT_ALWAYS_ASSERT( has_value(), "expected must have value" );
+#endif
+  return std::move(base_type::get_value());
+}
+
+//-----------------------------------------------------------------------------
+
+template<typename T, typename E>
+template<typename U>
+inline constexpr T bit::stl::expected<T,E>::value_or( U&& default_value )
+  const &
+{
+  return bool(*this) ? base_type::get_value() : std::forward<U>(default_value);
+}
+
+template<typename T, typename E>
+template<typename U>
+inline constexpr T bit::stl::expected<T,E>::value_or( U&& default_value )
+  &&
+{
+  return bool(*this) ? base_type::get_value() : std::forward<U>(default_value);
+}
+
+//-----------------------------------------------------------------------------
+
+template<typename T, typename E>
+constexpr E& bit::stl::expected<T,E>::error()
+  &
+{
+  return get_unexpected().value();
+}
+
+template<typename T, typename E>
+constexpr E&& bit::stl::expected<T,E>::error()
+  &&
+{
+  return std::move(get_unexpected().value());
+}
+template<typename T, typename E>
+constexpr const E& bit::stl::expected<T,E>::error()
+  const &
+{
+  return get_unexpected().value();
+}
+template<typename T, typename E>
+constexpr const E&& bit::stl::expected<T,E>::error()
+  const &&
+{
+  return std::move(get_unexpected().value());
+}
+
+//-----------------------------------------------------------------------------
+
+template<typename T, typename E>
+template<typename U>
+inline constexpr E bit::stl::expected<T,E>::error_or( U&& default_value )
+  const &
+{
+  return !bool(*this) ? base_type::get_unexpected().value() : default_value;
+}
+
+template<typename T, typename E>
+template<typename U>
+inline constexpr E bit::stl::expected<T,E>::error_or( U&& default_value )
+  &&
+{
+  return !bool(*this) ? base_type::get_unexpected().value() : default_value;
+}
+
+//-----------------------------------------------------------------------------
+
+template<typename T, typename E>
+inline constexpr bit::stl::unexpected_type<E>&
+  bit::stl::expected<T,E>::get_unexpected()
+  &
+{
+#if BIT_COMPILER_EXCEPTIONS_ENABLED
+  if( !has_error() ) {
+    throw bad_expected_access<void>();
+  }
+#else
+  BIT_ALWAYS_ASSERT( has_error(), "expected must have error" );
+#endif
+
+  return base_type::get_unexpected();
+}
+
+template<typename T, typename E>
+inline constexpr bit::stl::unexpected_type<E>&&
+  bit::stl::expected<T,E>::get_unexpected()
+  &&
+{
+#if BIT_COMPILER_EXCEPTIONS_ENABLED
+  if( !has_error() ) {
+    throw bad_expected_access<void>();
+  }
+#else
+  BIT_ALWAYS_ASSERT( has_error(), "expected must have error" );
+#endif
+
+  return std::move(base_type::get_unexpected());
+}
+
+template<typename T, typename E>
+inline constexpr const bit::stl::unexpected_type<E>&
+  bit::stl::expected<T,E>::get_unexpected()
+  const &
+{
+#if BIT_COMPILER_EXCEPTIONS_ENABLED
+  if( !has_error() ) {
+    throw bad_expected_access<void>();
+  }
+#else
+  BIT_ALWAYS_ASSERT( has_error(), "expected must have error" );
+#endif
+
+  return base_type::get_unexpected();
+}
+
+template<typename T, typename E>
+inline constexpr const bit::stl::unexpected_type<E>&&
+  bit::stl::expected<T,E>::get_unexpected()
+  const &&
+{
+#if BIT_COMPILER_EXCEPTIONS_ENABLED
+  if( !has_error() ) {
+    throw bad_expected_access<void>();
+  }
+#else
+  BIT_ALWAYS_ASSERT( has_error(), "expected must have error" );
+#endif
+
+  return std::move(base_type::get_unexpected());
+}
+
+#endif /* BIT_STL_UTILITIES_DETAIL_EXPECTED_INL */

--- a/include/bit/stl/utilities/detail/tribool.inl
+++ b/include/bit/stl/utilities/detail/tribool.inl
@@ -83,6 +83,20 @@ inline constexpr bool
   return lhs == tribool(indeterminate);
 }
 
+inline constexpr bool bit::stl::operator==( const tribool& lhs, bool rhs )
+  noexcept
+{
+  return lhs == tribool(rhs);
+}
+
+inline constexpr bool bit::stl::operator==( bool lhs, const tribool& rhs )
+  noexcept
+{
+  return tribool(lhs) == rhs;
+}
+
+//----------------------------------------------------------------------------
+
 inline constexpr bool
   bit::stl::operator!=( const tribool& lhs, const tribool& rhs )
   noexcept
@@ -102,6 +116,18 @@ inline constexpr bool
   noexcept
 {
   return lhs != tribool(indeterminate);
+}
+
+inline constexpr bool bit::stl::operator!=( const tribool& lhs, bool rhs )
+  noexcept
+{
+  return lhs != tribool(rhs);
+}
+
+inline constexpr bool bit::stl::operator!=( bool lhs, const tribool& rhs )
+  noexcept
+{
+  return tribool(lhs) != rhs;
 }
 
 //----------------------------------------------------------------------------

--- a/include/bit/stl/utilities/expected.hpp
+++ b/include/bit/stl/utilities/expected.hpp
@@ -15,6 +15,7 @@
 #include "in_place.hpp"
 #include "tribool.hpp"
 #include "compiler_traits.hpp" // BIT_COMPILER_EXCEPTIONS_ENABLED
+#include "assert.hpp"          // BIT_ALWAYS_ASSERT
 
 #include <initializer_list> // std::initializer_list
 #include <stdexcept>        // std::logic_error

--- a/include/bit/stl/utilities/expected.hpp
+++ b/include/bit/stl/utilities/expected.hpp
@@ -32,7 +32,7 @@ namespace bit {
     /// \brief The exception type thrown when accessing a non-active expected
     ///        member
     ///
-    /// \tparam Error the error type
+    /// \tparam E the error type
     ///////////////////////////////////////////////////////////////////////////
     template<typename E>
     class bad_expected_access : public std::logic_error
@@ -868,98 +868,98 @@ namespace bit {
     // X.Z.8, Expected relational operators
     //=========================================================================
 
-    template<typename T, typename Error>
-    constexpr bool operator==( const expected<T,Error>& lhs,
-                               const expected<T,Error>& rhs );
-    template<typename T, typename Error>
-    constexpr bool operator!=( const expected<T,Error>& lhs,
-                               const expected<T,Error>& rhs );
-    template<typename T, typename Error>
-    constexpr bool operator<( const expected<T,Error>& lhs,
-                              const expected<T,Error>& rhs );
-    template<typename T, typename Error>
-    constexpr bool operator>( const expected<T,Error>& lhs,
-                              const expected<T,Error>& rhs );
-    template<typename T, typename Error>
-    constexpr bool operator<=( const expected<T,Error>& lhs,
-                               const expected<T,Error>& rhs );
-    template<typename T, typename Error>
-    constexpr bool operator>=( const expected<T,Error>& lhs,
-                               const expected<T,Error>& rhs );
+    template<typename T, typename E>
+    constexpr bool operator==( const expected<T,E>& lhs,
+                               const expected<T,E>& rhs );
+    template<typename T, typename E>
+    constexpr bool operator!=( const expected<T,E>& lhs,
+                               const expected<T,E>& rhs );
+    template<typename T, typename E>
+    constexpr bool operator<( const expected<T,E>& lhs,
+                              const expected<T,E>& rhs );
+    template<typename T, typename E>
+    constexpr bool operator>( const expected<T,E>& lhs,
+                              const expected<T,E>& rhs );
+    template<typename T, typename E>
+    constexpr bool operator<=( const expected<T,E>& lhs,
+                               const expected<T,E>& rhs );
+    template<typename T, typename E>
+    constexpr bool operator>=( const expected<T,E>& lhs,
+                               const expected<T,E>& rhs );
 
     //=========================================================================
     // X.Z.9, Comparison with T
     //=========================================================================
 
-    template<typename T, typename Error>
-    constexpr bool operator==( const expected<T,Error>& lhs, const T& rhs );
-    template<typename T, typename Error>
-    constexpr bool operator==( const T& lhs, const expected<T,Error>& rhs );
-    template<typename T, typename Error>
-    constexpr bool operator!=( const expected<T,Error>& lhs, const T& rhs );
-    template<typename T, typename Error>
-    constexpr bool operator!=( const T& lhs, const expected<T,Error>& rhs );
-    template<typename T, typename Error>
-    constexpr bool operator<( const expected<T,Error>& lhs, const T& rhs );
-    template<typename T, typename Error>
-    constexpr bool operator<( const T& lhs, const expected<T,Error>& rhs );
-    template<typename T, typename Error>
-    constexpr bool operator<=( const expected<T,Error>& lhs, const T& rhs );
-    template<typename T, typename Error>
-    constexpr bool operator<=( const T& lhs, const expected<T,Error>& rhs );
-    template<typename T, typename Error>
-    constexpr bool operator>( const expected<T,Error>& lhs, const T& rhs );
-    template<typename T, typename Error>
-    constexpr bool operator>( const T& lhs, const expected<T,Error>& rhs );
-    template<typename T, typename Error>
-    constexpr bool operator>=( const expected<T,Error>& lhs, const T& rhs );
-    template<typename T, typename Error>
-    constexpr bool operator>=( const T& lhs, const expected<T,Error>& rhs );
+    template<typename T, typename E>
+    constexpr bool operator==( const expected<T,E>& x, const T& v );
+    template<typename T, typename E>
+    constexpr bool operator==( const T& v, const expected<T,E>& x );
+    template<typename T, typename E>
+    constexpr bool operator!=( const expected<T,E>& x, const T& v );
+    template<typename T, typename E>
+    constexpr bool operator!=( const T& v, const expected<T,E>& x );
+    template<typename T, typename E>
+    constexpr bool operator<( const expected<T,E>& x, const T& v );
+    template<typename T, typename E>
+    constexpr bool operator<( const T& v, const expected<T,E>& x );
+    template<typename T, typename E>
+    constexpr bool operator<=( const expected<T,E>& x, const T& v );
+    template<typename T, typename E>
+    constexpr bool operator<=( const T& v, const expected<T,E>& x );
+    template<typename T, typename E>
+    constexpr bool operator>( const expected<T,E>& x, const T& v );
+    template<typename T, typename E>
+    constexpr bool operator>( const T& v, const expected<T,E>& x );
+    template<typename T, typename E>
+    constexpr bool operator>=( const expected<T,E>& x, const T& v );
+    template<typename T, typename E>
+    constexpr bool operator>=( const T& v, const expected<T,E>& x );
 
     //=========================================================================
     // X.Z.10, Comparison with unexpected_type<E>
     //=========================================================================
 
-    template<typename T, typename Error>
-    constexpr bool operator==( const expected<T,Error>& lhs,
-                               const unexpected_type<Error>& rhs );
-    template<typename T, typename Error>
-    constexpr bool operator==( const unexpected_type<Error>& lhs,
-                               const expected<T,Error>& rhs );
-    template<typename T, typename Error>
-    constexpr bool operator!=( const expected<T,Error>& lhs,
-                               const unexpected_type<Error>& rhs);
-    template<typename T, typename Error>
-    constexpr bool operator!=( const unexpected_type<Error>& lhs,
-                               const expected<T,Error>& rhs );
-    template<typename T, typename Error>
-    constexpr bool operator<( const expected<T,Error>& lhs,
-                              const unexpected_type<Error>& rhs );
-    template<typename T, typename Error>
-    constexpr bool operator<( const unexpected_type<Error>& lhs,
-                              const expected<T,Error>& rhs );
-    template<typename T, typename Error>
-    constexpr bool operator<=( const expected<T,Error>& lhs,
-                               const unexpected_type<Error>& rhs );
-    template<typename T, typename Error>
-    constexpr bool operator<=( const unexpected_type<Error>& lhs,
-                               const expected<T,Error>& rhs );
-    template<typename T, typename Error>
-    constexpr bool operator>( const expected<T,Error>& lhs,
-                              const unexpected_type<Error>& rhs);
-    template<typename T, typename Error>
-    constexpr bool operator>( const unexpected_type<Error>& lhs,
-                              const expected<T,Error>& rhs ) ;
-    template<typename T, typename Error>
-    constexpr bool operator>=( const expected<T,Error>& lhs,
-                               const unexpected_type<Error>& rhs );
-    template<typename T, typename Error>
-    constexpr bool operator>=( const unexpected_type<Error>& lhs,
-                               const expected<T,Error>& rhs );
+    template<typename T, typename E>
+    constexpr bool operator==( const expected<T,E>& x,
+                               const unexpected_type<E>& e );
+    template<typename T, typename E>
+    constexpr bool operator==( const unexpected_type<E>& e,
+                               const expected<T,E>& x );
+    template<typename T, typename E>
+    constexpr bool operator!=( const expected<T,E>& x,
+                               const unexpected_type<E>& e );
+    template<typename T, typename E>
+    constexpr bool operator!=( const unexpected_type<E>& e,
+                               const expected<T,E>& x );
+    template<typename T, typename E>
+    constexpr bool operator<( const expected<T,E>& x,
+                              const unexpected_type<E>& e );
+    template<typename T, typename E>
+    constexpr bool operator<( const unexpected_type<E>& e,
+                              const expected<T,E>& x );
+    template<typename T, typename E>
+    constexpr bool operator<=( const expected<T,E>& x,
+                               const unexpected_type<E>& e );
+    template<typename T, typename E>
+    constexpr bool operator<=( const unexpected_type<E>& e,
+                               const expected<T,E>& x );
+    template<typename T, typename E>
+    constexpr bool operator>( const expected<T,E>& x,
+                              const unexpected_type<E>& e );
+    template<typename T, typename E>
+    constexpr bool operator>( const unexpected_type<E>& e,
+                              const expected<T,E>& x ) ;
+    template<typename T, typename E>
+    constexpr bool operator>=( const expected<T,E>& x,
+                               const unexpected_type<E>& e );
+    template<typename T, typename E>
+    constexpr bool operator>=( const unexpected_type<E>& e,
+                               const expected<T,E>& x );
 
     // X.Z.11, Specialized algorithms
-    template<typename T, typename Error>
-    void swap( expected<T,Error>& lhs, expected<T,Error>& rhs );
+    template<typename T, typename E>
+    void swap( expected<T,E>& lhs, expected<T,E>& rhs );
 
     // X.Z.12, Factories
 

--- a/include/bit/stl/utilities/expected.hpp
+++ b/include/bit/stl/utilities/expected.hpp
@@ -319,7 +319,7 @@ namespace bit {
         union storage_type
         {
           constexpr storage_type()
-            : empty{}
+            : dummy{}
           {
 
           }
@@ -338,7 +338,7 @@ namespace bit {
 
           }
 
-          empty<void>        empty;
+          empty<void>        dummy;
           T                  value;
           unexpected_type<E> error;
         };
@@ -426,7 +426,7 @@ namespace bit {
         union storage_type
         {
           constexpr storage_type()
-            : empty{}
+            : dummy{}
           {
 
           }
@@ -447,7 +447,7 @@ namespace bit {
 
           ~storage_type(){}
 
-          empty<void>        empty;
+          empty<void>        dummy;
           T                  value;
           unexpected_type<E> error;
         };

--- a/include/bit/stl/utilities/expected.hpp
+++ b/include/bit/stl/utilities/expected.hpp
@@ -1,0 +1,976 @@
+/**
+ * \file expected.hpp
+ *
+ * \brief TODO: Add description
+ *
+ * \author Matthew Rodusek (matthew.rodusek@gmail.com)
+ */
+#ifndef BIT_STL_UTILITIES_EXPECTED_HPP
+#define BIT_STL_UTILITIES_EXPECTED_HPP
+
+#include "../traits/composition/bool_constant.hpp"
+#include "../traits/composition/empty.hpp"
+#include "../traits/composition/sfinae.hpp"
+
+#include "in_place.hpp"
+#include "tribool.hpp"
+#include "compiler_traits.hpp" // BIT_COMPILER_EXCEPTIONS_ENABLED
+
+#include <initializer_list> // std::initializer_list
+#include <stdexcept>        // std::logic_error
+#include <type_traits>  // std::is_constructible
+#include <system_error> // std::error_condition
+
+namespace bit {
+  namespace stl {
+
+    //=========================================================================
+    // X.Z.7, class bad_expected_access
+    //=========================================================================
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// \brief The exception type thrown when accessing a non-active expected
+    ///        member
+    ///
+    /// \tparam Error the error type
+    ///////////////////////////////////////////////////////////////////////////
+    template<typename E>
+    class bad_expected_access : public std::logic_error
+    {
+      //-----------------------------------------------------------------------
+      // Public Member Types
+      //-----------------------------------------------------------------------
+    public:
+
+      using error_type = E;
+
+      //-----------------------------------------------------------------------
+      // Constructors
+      //-----------------------------------------------------------------------
+    public:
+
+      /// \brief Constructs a bad_expected_access from a given error, \p e
+      ///
+      /// \param e the error
+      explicit bad_expected_access( error_type e );
+
+      //-----------------------------------------------------------------------
+      // Observers
+      //-----------------------------------------------------------------------
+    public:
+
+      /// \{
+      /// \brief Gets the underlying error
+      ///
+      /// \return the error type
+      error_type& error() & noexcept;
+      error_type&& error() && noexcept;
+      const error_type& error() const & noexcept;
+      const error_type&& error() const && noexcept;
+      /// \}
+
+      //-----------------------------------------------------------------------
+      // Private Members
+      //-----------------------------------------------------------------------
+    private:
+
+      error_type m_error_value;
+    };
+
+    //=========================================================================
+
+    template<>
+    class bad_expected_access<void> : std::logic_error
+    {
+      //-----------------------------------------------------------------------
+      // Constructors
+      //-----------------------------------------------------------------------
+    public:
+
+      /// \brief Constructs a bad_expected_access
+      bad_expected_access();
+
+    };
+
+    //=========================================================================
+    // X.Y.3, unexpected_type
+    //=========================================================================
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// \brief A type representing an unexpected value coming from an expected
+    ///        type
+    ///
+    /// \tparam E the unexpected type
+    ///////////////////////////////////////////////////////////////////////////
+    template<typename E>
+    class unexpected_type
+    {
+      //-----------------------------------------------------------------------
+      // Constructors
+      //-----------------------------------------------------------------------
+    public:
+
+      // Deleted default constructor
+      unexpected_type() = delete;
+
+      /// \brief Moves an unexpected_type from an existing one
+      ///
+      /// \param other the other unexpected_type to move
+      constexpr unexpected_type( unexpected_type&& other ) = default;
+
+      /// \brief Copies an unexpected_type from an existing one
+      ///
+      /// \param other the other unexpected_type to copy
+      constexpr unexpected_type( const unexpected_type& other ) = default;
+
+      /// \brief Move-converts an expected_type to this type
+      ///
+      /// \note This constructor only participates in overload resolution if E2
+      ///       is convertible to E
+      ///
+      /// \param other the other unexpected_type to move-convert
+      template<typename E2, typename = std::enable_if_t<std::is_convertible<E2,E>::value>>
+      constexpr unexpected_type( unexpected_type<E2>&& other );
+
+      /// \brief Copy converts an expected_Type to this type
+      ///
+      /// \note This constructor only participates in overload resolution if E2
+      ///       is convertible to E
+      ///
+      /// \param other the other unexpected_type to copy-convert
+      template<typename E2, typename = std::enable_if_t<std::is_convertible<E2,E>::value>>
+      constexpr unexpected_type( const unexpected_type<E2>& other );
+
+      /// \brief Constructs the expected_type by copying the underlying
+      ///        unexpected_type by value
+      ///
+      /// \param value the value to copy
+      constexpr explicit unexpected_type( const E& value );
+
+      /// \brief Constructs the expected_type by copying the underlying
+      ///        unexpected_type by value
+      ///
+      /// \param value the value to copy
+      constexpr explicit unexpected_type( E&& value );
+
+      /// \brief Constructs the underlying unexpected_type by forwarding \p args
+      ///        to \p E's constructor
+      ///
+      /// \throws ... any exception that E's constructor may throw
+      /// \param args the arguments to forward
+      template<typename...Args, typename = std::enable_if_t<std::is_constructible<E,Args...>::value>>
+      constexpr explicit unexpected_type( in_place_t, Args&&...args );
+
+      /// \brief Constructs the underlying unexpected_type by forwarding \p args
+      ///        to \p E's constructor
+      ///
+      /// \throws ... any exception that E's constructor may throw
+      /// \param ilist an initializer list of arguments
+      /// \param args the arguments to forward
+      template<typename U, typename...Args, typename = std::enable_if_t<std::is_constructible<E,std::initializer_list<U>,Args...>::value>>
+      constexpr explicit unexpected_type( in_place_t,
+                                          std::initializer_list<U> ilist,
+                                          Args&&...args );
+
+      //-----------------------------------------------------------------------
+      // Observers
+      //-----------------------------------------------------------------------
+    public:
+
+      /// \{
+      /// \brief Extracts the value for this unexpected_type
+      ///
+      /// \return reference to the value
+      constexpr E& value() &;
+      constexpr const E& value() const &;
+      constexpr E&& value() &&;
+      constexpr const E&& value() const &&;
+      /// \}
+
+      //-----------------------------------------------------------------------
+      // Private Members
+      //-----------------------------------------------------------------------
+    private:
+
+      E m_value;
+    };
+
+    //=========================================================================
+    // X.Y.4, Unexpected factories
+    //=========================================================================
+
+    /// \brief Makes an unexpected type \c E
+    ///
+    /// \tparam E the unexpected type to make
+    /// \param args the arguments to forward
+    /// \return the unexpected type
+    template<typename E, typename...Args>
+    constexpr unexpected_type<E> make_unexpected( Args&&...args );
+
+    //=========================================================================
+    // X.Y.5, unexpected_type relational operators
+    //=========================================================================
+
+    template<typename E>
+    constexpr bool operator==( const unexpected_type<E>& lhs,
+                               const unexpected_type<E>& rhs );
+    template<typename E>
+    constexpr bool operator!=( const unexpected_type<E>& lhs,
+                               const unexpected_type<E>& rhs );
+    template<typename E>
+    constexpr bool operator<( const unexpected_type<E>& lhs,
+                              const unexpected_type<E>& rhs );
+    template<typename E>
+    constexpr bool operator>( const unexpected_type<E>& lhs,
+                              const unexpected_type<E>& rhs );
+    template<typename E>
+    constexpr bool operator<=( const unexpected_type<E>& lhs,
+                               const unexpected_type<E>& rhs );
+    template<typename E>
+    constexpr bool operator>=( const unexpected_type<E>& lhs,
+                               const unexpected_type<E>& rhs );
+
+    //=========================================================================
+    // X.Z.6, unexpect tag
+    //=========================================================================
+
+    /// \brief A tag type used for tag-dispatch
+    struct unexpect_t
+    {
+      unexpect_t() = delete;
+      constexpr unexpect_t(int){}
+    };
+
+    constexpr unexpect_t unexpect{0};
+
+    //=========================================================================
+    // X.Z.4, expected for object types
+    //=========================================================================
+
+    namespace detail {
+
+      //=======================================================================
+      // expected_base
+      //=======================================================================
+
+      template<bool Trivial, typename T, typename E>
+      class expected_base;
+
+      template<typename T, typename E>
+      class expected_base<true,T,E>
+      {
+        //-----------------------------------------------------------------------
+        // Constructors
+        //-----------------------------------------------------------------------
+      public:
+
+        constexpr expected_base();
+        template<typename...Args>
+        constexpr expected_base( in_place_t, Args&&...args );
+        template<typename...Args>
+        constexpr expected_base( unexpect_t, Args&&...args );
+
+        //---------------------------------------------------------------------
+        // Observers
+        //---------------------------------------------------------------------
+      protected:
+
+        constexpr bool has_value() const noexcept;
+        constexpr bool has_error() const noexcept;
+        constexpr bool valueless_by_exception() const noexcept;
+
+        //---------------------------------------------------------------------
+
+        constexpr T& get_value() & noexcept;
+        constexpr T&& get_value() && noexcept;
+        constexpr const T& get_value() const & noexcept;
+        constexpr const T&& get_value() const && noexcept;
+
+        //---------------------------------------------------------------------
+
+        constexpr unexpected_type<E>& get_unexpected() & noexcept;
+        constexpr unexpected_type<E>&& get_unexpected() && noexcept;
+        constexpr const unexpected_type<E>& get_unexpected() const & noexcept;
+        constexpr const unexpected_type<E>&& get_unexpected() const && noexcept;
+
+        //---------------------------------------------------------------------
+        // Modifiers
+        //---------------------------------------------------------------------
+      protected:
+
+        template<typename...Args>
+        void emplace_value( Args&&...args );
+        template<typename...Args>
+        void emplace_error( Args&&...args );
+
+        //---------------------------------------------------------------------
+
+        template<typename U>
+        void assign_value( U&& value );
+        template<typename U>
+        void assign_error( U&& error );
+
+        //---------------------------------------------------------------------
+        // Protected Member Types
+        //---------------------------------------------------------------------
+      protected:
+
+        union storage_type
+        {
+          using value_type = std::conditional_t<std::is_void<T>::value,empty<void>,T>;
+
+          constexpr storage_type()
+            : empty{}
+          {
+
+          }
+
+          template<typename...Args>
+          constexpr storage_type( in_place_t, Args&&...args )
+            : value( std::forward<Args>(args)... )
+          {
+
+          }
+
+          template<typename...Args>
+          constexpr storage_type( unexpect_t, Args&&...args )
+            : error( std::forward<Args>(args)... )
+          {
+
+          }
+
+          empty<void>        empty;
+          value_type         value;
+          unexpected_type<E> error;
+        };
+
+        //---------------------------------------------------------------------
+        // Private Members
+        //---------------------------------------------------------------------
+      private:
+
+        storage_type m_storage;
+        tribool      m_has_value;
+      };
+
+      //=======================================================================
+
+      template<typename T, typename E>
+      class expected_base<false,T,E>
+      {
+        //---------------------------------------------------------------------
+        // Constructors / Destructor
+        //---------------------------------------------------------------------
+      public:
+
+        constexpr expected_base();
+        template<typename...Args>
+        constexpr expected_base( in_place_t, Args&&...args );
+        template<typename...Args>
+        constexpr expected_base( unexpect_t, Args&&...args );
+
+        //---------------------------------------------------------------------
+
+        ~expected_base();
+
+        //---------------------------------------------------------------------
+        // Observers
+        //---------------------------------------------------------------------
+      protected:
+
+        constexpr bool has_value() const noexcept;
+        constexpr bool has_error() const noexcept;
+        constexpr bool valueless_by_exception() const noexcept;
+
+        //---------------------------------------------------------------------
+
+        constexpr T& get_value() & noexcept;
+        constexpr T&& get_value() && noexcept;
+        constexpr const T& get_value() const & noexcept;
+        constexpr const T&& get_value() const && noexcept;
+
+        //---------------------------------------------------------------------
+
+        constexpr unexpected_type<E>& get_unexpected() & noexcept;
+        constexpr unexpected_type<E>&& get_unexpected() && noexcept;
+        constexpr const unexpected_type<E>& get_unexpected() const & noexcept;
+        constexpr const unexpected_type<E>&& get_unexpected() const && noexcept;
+
+        //---------------------------------------------------------------------
+        // Modifiers
+        //---------------------------------------------------------------------
+      protected:
+
+        void destruct();
+
+        //---------------------------------------------------------------------
+
+        template<typename...Args>
+        void emplace_value( Args&&...args );
+
+        template<typename...Args>
+        void emplace_error( Args&&...args );
+
+        //---------------------------------------------------------------------
+
+        template<typename U>
+        void assign_value( U&& value );
+
+        template<typename U>
+        void assign_error( U&& error );
+
+        //---------------------------------------------------------------------
+        // Protected Member Types
+        //---------------------------------------------------------------------
+      protected:
+
+        union storage_type
+        {
+          using value_type = std::conditional_t<std::is_void<T>::value,empty<void>,T>;
+
+          constexpr storage_type()
+            : empty{}
+          {
+
+          }
+
+          template<typename...Args>
+          constexpr storage_type( in_place_t, Args&&...args )
+            : value( std::forward<Args>(args)... )
+          {
+
+          }
+
+          template<typename...Args>
+          constexpr storage_type( unexpect_t, Args&&...args )
+            : error( std::forward<Args>(args)... )
+          {
+
+          }
+
+          ~storage_type(){}
+
+          empty<void>        empty;
+          value_type         value;
+          unexpected_type<E> error;
+        };
+
+        //---------------------------------------------------------------------
+        // Private Members
+        //---------------------------------------------------------------------
+      private:
+
+        storage_type m_storage;
+        tribool      m_has_value;
+      };
+    } // namespace detail
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// \brief
+    ///
+    /// \tparam T the type
+    /// \tparam Error the error type
+    ///////////////////////////////////////////////////////////////////////////
+    template<typename T, typename E=std::error_condition>
+    class expected
+      : detail::expected_base<std::is_trivially_destructible<T>::value &&
+                              std::is_trivially_destructible<E>::value,T,E>
+    {
+      using base_type = detail::expected_base<std::is_trivially_destructible<T>::value &&
+                                              std::is_trivially_destructible<E>::value,T,E>;
+
+      template<typename U, typename G>
+      static constexpr bool is_constructible = std::is_constructible<T, U&>::value &&
+                                               std::is_constructible<E, G&>::value;
+
+
+      template<typename U, typename G>
+      static constexpr bool is_copyable = std::is_copy_constructible<U>::value &&
+                                          std::is_copy_assignable<U>::value &&
+                                          std::is_copy_constructible<G>::value &&
+                                          std::is_copy_assignable<G>::value;
+      template<typename U, typename G>
+      static constexpr bool is_moveable = std::is_move_constructible<U>::value &&
+                                          std::is_move_assignable<U>::value &&
+                                          std::is_move_constructible<G>::value &&
+                                          std::is_move_assignable<G>::value;
+
+      template<typename U, typename V>
+      static constexpr bool is_value_assignable = std::is_constructible<U,V>::value &&
+                                                  std::is_assignable<U,V>::value;
+
+      //-----------------------------------------------------------------------
+      // Public Member Types
+      //-----------------------------------------------------------------------
+    public:
+
+      using value_type = T;
+      using error_type = E;
+
+      template<typename U>
+      struct rebind
+      {
+        using type = expected<U, error_type>;
+      };
+
+      //-----------------------------------------------------------------------
+      // Constructors / Destructor / Assignment
+      //-----------------------------------------------------------------------
+    public:
+
+      // X.Z.4.1, constructors
+
+      /// \brief Initializes the contained value as if direct-non-list-
+      ///        initializing an object of type T with the expression T{}
+      ///
+      /// \post \code bool(*this) \endcode
+      template<typename U=T,typename = std::enable_if_t<std::is_default_constructible<T>::value>>
+      constexpr expected();
+
+      //-----------------------------------------------------------------------
+
+      /// \brief Copy-constructs an expected from an existing expected
+      ///
+      /// \param other the other expected
+      expected( enable_overload_if<std::is_copy_constructible<T>::value &&
+                                   std::is_copy_constructible<E>::value,
+                                   const expected&> other );
+      expected( disable_overload_if<std::is_copy_constructible<T>::value &&
+                                    std::is_copy_constructible<E>::value,
+                                    const expected&> other ) = delete;
+
+      //-----------------------------------------------------------------------
+
+      /// \brief Move-constructs an expected from an existing expected
+      ///
+      /// \param other the other expected
+      expected( enable_overload_if<std::is_move_constructible<T>::value &&
+                                   std::is_move_constructible<E>::value,
+                                   expected&&> other );
+      expected( disable_overload_if<std::is_move_constructible<T>::value &&
+                                    std::is_move_constructible<E>::value,
+                                    expected&&> other ) = delete;
+
+      //-----------------------------------------------------------------------
+
+      /// \brief Copy converts an expected from an existing expected
+      ///
+      /// \param other the other expected
+#ifndef BIT_DOXYGEN
+      template<typename U, typename G, typename = std::enable_if_t<std::is_constructible<T,const U&>::value &&
+                                                                   std::is_constructible<E,const G&>::value>>
+#else
+      template<typename U, typename G>
+#endif
+      expected( const expected<U,G>& other );
+
+      /// \brief Copy converts an expected from an existing expected
+      ///
+      /// \param other the other expected
+#ifndef BIT_DOXYGEN
+      template<typename U, typename G, typename = std::enable_if_t<std::is_constructible<T,U&&>::value &&
+                                                                   std::is_constructible<E,G&&>::value>>
+#else
+      template<typename U, typename G>
+#endif
+      expected( expected<U,G>&& other );
+
+      //-----------------------------------------------------------------------
+
+      /// \brief Constructs the underlying value of the expected from \p value
+      ///
+      /// \param value the value to construct the underlying expected
+      template<typename U=T,typename = std::enable_if_t<std::is_copy_constructible<U>::value>>
+      constexpr expected( const T& value );
+
+      /// \brief Constructs the underlying value of the expected from \p value
+      ///
+      /// \param value the value to construct the underlying expected
+      template<typename U=T,typename = std::enable_if_t<std::is_move_constructible<U>::value>>
+      constexpr expected( T&& value );
+
+      //-----------------------------------------------------------------------
+
+      /// \brief Constructs the underlying value of the expected by
+      ///        constructing the value in place
+      ///
+      /// \param args the arguments to forward
+      template<typename...Args, typename = std::enable_if_t<std::is_constructible<T,Args...>::value>>
+      constexpr explicit expected( in_place_t,
+                                   Args&&...args );
+
+      /// \brief Constructs the underlying value of the expected by
+      ///        constructing the value in place
+      ///
+      /// \param ilist an initializer list to forward
+      /// \param args the arguments to forward
+      template<typename U, typename...Args, typename = std::enable_if_t<std::is_constructible<T,std::initializer_list<U>,Args...>::value>>
+      constexpr explicit expected( in_place_t,
+                                   std::initializer_list<U> ilist,
+                                   Args&&...args );
+
+      //-----------------------------------------------------------------------
+
+      /// \brief Constructs the underlying error from a given unexpected type
+      ///
+      /// \param unexpected the unexpected type
+      template<typename UError=E, typename = std::enable_if_t<std::is_copy_constructible<UError>::value>>
+      constexpr expected( unexpected_type<E> const& unexpected );
+
+      /// \brief Constructs the underlying error from a given unexpected type
+      ///
+      /// \param unexpected the unexpected type
+      template<typename Err, typename = std::enable_if_t<std::is_convertible<Err,E>::value>>
+      constexpr expected( unexpected_type<Err> const& unexpected );
+
+      //-----------------------------------------------------------------------
+
+      /// \brief Constructs the underlying error of the expected by
+      ///        constructing the value in place
+      ///
+      /// \param args the arguments to forward
+      template<typename...Args, typename = std::enable_if_t<std::is_constructible<E, Args...>::value>>
+      constexpr explicit expected( unexpect_t,
+                                   Args&&...args );
+
+      /// \brief Constructs the underlying error of the expected by
+      ///        constructing the value in place
+      ///
+      /// \param ilist an initializer list to forward
+      /// \param args the arguments to forward
+      template<typename U, typename...Args, typename = std::enable_if_t<std::is_constructible<E,std::initializer_list<U>,Args...>::value>>
+      constexpr explicit expected( unexpect_t,
+                                   std::initializer_list<U> ilist,
+                                   Args&&...args );
+
+      //-----------------------------------------------------------------------
+
+      // X.Z.4.3, assignment
+      template<typename U=T,typename F=E,typename = std::enable_if_t<is_copyable<U,F>>>
+      expected& operator=( const expected& other );
+
+      template<typename U=T,typename F=E,typename = std::enable_if_t<is_moveable<U,F>>>
+      expected& operator=( expected&& other );
+
+      template<typename U,typename = std::enable_if<is_value_assignable<T,U>>>
+      expected& operator=( U&& value );
+
+      expected& operator=( const unexpected_type<E>& unexpected );
+
+      expected& operator=( unexpected_type<E>&& unexpected );
+
+      //-----------------------------------------------------------------------
+      // Modifiers
+      //-----------------------------------------------------------------------
+    public:
+
+      /// \brief Consturcts the underlying value type in-place
+      ///
+      /// If the expected already contains a value, it is destructed first.
+      ///
+      /// \param args the arguments to forward to \c T's constructors
+      template<typename...Args, typename = std::enable_if_t<std::is_constructible<T,Args...>::value>>
+      void emplace( Args&&...args );
+
+      /// \brief Consturcts the underlying value type in-place
+      ///
+      /// If the expected already contains a value, it is destructed first.
+      ///
+      /// \param ilist the initializer list of arguments to forward
+      /// \param args the arguments to forward to \c T's constructors
+      template<typename U, typename...Args, typename = std::enable_if_t<std::is_constructible<T,Args...>::value>>
+      void emplace( std::initializer_list<U> ilist, Args&&...args );
+
+      /// \brief Swaps this expected with \p other
+      ///
+      /// \param other the other expected to swap
+      void swap( expected& other );
+
+      //-----------------------------------------------------------------------
+      // Observers
+      //-----------------------------------------------------------------------
+    public:
+
+      // X.Z.4.5, observers
+
+      /// \brief Queries whether the expected has a value
+      ///
+      /// \return \c true if the expected has a value
+      constexpr bool has_value() const noexcept;
+
+      /// \brief Queries whether the expected has an error
+      ///
+      /// \return \c true if the expected has an error
+      constexpr bool has_error() const noexcept;
+
+      /// \brief Queries whether the expected is valueless_by_exception
+      ///
+      /// \return \c true if the expected is valueless-by-exception
+      constexpr bool valueless_by_exception() const noexcept;
+
+      /// \brief Explicitly convertible to \c bool
+      ///
+      /// \return \c true if the expected has a value
+      constexpr explicit operator bool() const noexcept;
+
+      //-----------------------------------------------------------------------
+
+      constexpr T* operator->();
+      constexpr const T* operator->() const;
+
+      constexpr T& operator*() &;
+      constexpr const T& operator*() const&;
+      constexpr T&& operator*() &&;
+      constexpr const T&& operator*() const &&;
+
+      //-----------------------------------------------------------------------
+
+      constexpr const T& value() const&;
+      constexpr T& value() &;
+      constexpr const T&& value() const &&;
+      constexpr T&& value() &&;
+
+      /// \{
+      /// \brief Gets the underlying value if there is an value, otherwise
+      ///        returns \p default_value
+      ///
+      /// \param default_value the default value to use
+      /// \return the value
+      template<typename U>
+      constexpr T value_or( U&& default_value ) const &;
+      template<typename U>
+      constexpr T value_or( U&& default_value ) &&;
+      /// \}
+
+      //-----------------------------------------------------------------------
+
+      /// \{
+      /// \brief Gets the underlying error
+      ///
+      /// \throw bad_expected_access<void> if not currently in an error state
+      /// \return reference to the underlying error
+      constexpr E& error() &;
+      constexpr E&& error() &&;
+      constexpr const E& error() const &;
+      constexpr const E&& error() const &&;
+      /// \}
+
+      /// \{
+      /// \brief Gets the underlying error if there is an error, otherwise
+      ///        returns \p default_value
+      ///
+      /// \param default_value the default value to use
+      /// \return the error
+      template<typename U>
+      constexpr E error_or( U&& default_value ) const &;
+      template<typename U>
+      constexpr E error_or( U&& default_value ) &&;
+      /// \}
+
+      //-----------------------------------------------------------------------
+
+      /// \{
+      /// \brief Gets the underlying expected type
+      ///
+      /// \throw bad_expected_access<void> if not currently in an error state
+      /// \return reference to the unexpected_type
+      constexpr unexpected_type<E>& get_unexpected() &;
+      constexpr unexpected_type<E>&& get_unexpected() &&;
+      constexpr const unexpected_type<E>& get_unexpected() const &;
+      constexpr const unexpected_type<E>&& get_unexpected() const &&;
+      /// \}
+
+    };
+
+    //=========================================================================
+    // X.Z.5, Specialization for void.
+    //=========================================================================
+
+    template<typename E>
+    class expected<void, E>;
+
+    template<typename E>
+    class expected<void, E>
+    {
+      //-----------------------------------------------------------------------
+      // Public Member Types
+      //-----------------------------------------------------------------------
+    public:
+
+      using value_type = void;
+      using error_type = E;
+
+      template<typename U>
+      struct rebind
+      {
+        typedef expected<U, error_type> type;
+      };
+
+      //-----------------------------------------------------------------------
+      // Constructors / Destructor / Assignment
+      //-----------------------------------------------------------------------
+    public:
+
+      constexpr expected() noexcept;
+
+      expected(const expected&);
+
+      expected(expected&&)
+        noexcept(std::is_nothrow_move_constructible<E>::value);
+
+      constexpr explicit expected(in_place_t);
+
+      constexpr expected(unexpected_type<E> const&);
+
+      template<typename Err>
+      constexpr expected(unexpected_type<Err> const&);
+
+      //-----------------------------------------------------------------------
+
+      expected& operator=(const expected&);
+
+      expected& operator=(expected&&)
+        noexcept(std::is_nothrow_move_assignable<E>::value);
+
+      void emplace();
+
+      // ??, swap
+      void swap( expected& );
+
+      // ??, observers
+      constexpr explicit operator bool() const noexcept;
+      constexpr bool has_value() const noexcept;
+
+      void value() const;
+
+      constexpr E& error() &;
+      constexpr E&& error() &&;
+      constexpr const E& error() const&;
+      constexpr const E&& error() const&&;
+
+      constexpr unexpected_type<E> get_unexpected() const;
+
+      //-----------------------------------------------------------------------
+      // Private Members
+      //-----------------------------------------------------------------------
+    private:
+
+      union storage_type
+      {
+        empty<void> empty;
+        error_type  error;
+      };
+      storage_type m_storage;
+      bool         m_has_value; // exposition only
+    };
+
+    //=========================================================================
+    // X.Z.8, Expected relational operators
+    //=========================================================================
+
+    template<typename T, typename Error>
+    constexpr bool operator==( const expected<T,Error>& lhs,
+                               const expected<T,Error>& rhs );
+    template<typename T, typename Error>
+    constexpr bool operator!=( const expected<T,Error>& lhs,
+                               const expected<T,Error>& rhs );
+    template<typename T, typename Error>
+    constexpr bool operator<( const expected<T,Error>& lhs,
+                              const expected<T,Error>& rhs );
+    template<typename T, typename Error>
+    constexpr bool operator>( const expected<T,Error>& lhs,
+                              const expected<T,Error>& rhs );
+    template<typename T, typename Error>
+    constexpr bool operator<=( const expected<T,Error>& lhs,
+                               const expected<T,Error>& rhs );
+    template<typename T, typename Error>
+    constexpr bool operator>=( const expected<T,Error>& lhs,
+                               const expected<T,Error>& rhs );
+
+    //=========================================================================
+    // X.Z.9, Comparison with T
+    //=========================================================================
+
+    template<typename T, typename Error>
+    constexpr bool operator==( const expected<T,Error>& lhs, const T& rhs );
+    template<typename T, typename Error>
+    constexpr bool operator==( const T& lhs, const expected<T,Error>& rhs );
+    template<typename T, typename Error>
+    constexpr bool operator!=( const expected<T,Error>& lhs, const T& rhs );
+    template<typename T, typename Error>
+    constexpr bool operator!=( const T& lhs, const expected<T,Error>& rhs );
+    template<typename T, typename Error>
+    constexpr bool operator<( const expected<T,Error>& lhs, const T& rhs );
+    template<typename T, typename Error>
+    constexpr bool operator<( const T& lhs, const expected<T,Error>& rhs );
+    template<typename T, typename Error>
+    constexpr bool operator<=( const expected<T,Error>& lhs, const T& rhs );
+    template<typename T, typename Error>
+    constexpr bool operator<=( const T& lhs, const expected<T,Error>& rhs );
+    template<typename T, typename Error>
+    constexpr bool operator>( const expected<T,Error>& lhs, const T& rhs );
+    template<typename T, typename Error>
+    constexpr bool operator>( const T& lhs, const expected<T,Error>& rhs );
+    template<typename T, typename Error>
+    constexpr bool operator>=( const expected<T,Error>& lhs, const T& rhs );
+    template<typename T, typename Error>
+    constexpr bool operator>=( const T& lhs, const expected<T,Error>& rhs );
+
+    //=========================================================================
+    // X.Z.10, Comparison with unexpected_type<E>
+    //=========================================================================
+
+    template<typename T, typename Error>
+    constexpr bool operator==( const expected<T,Error>& lhs,
+                               const unexpected_type<Error>& rhs );
+    template<typename T, typename Error>
+    constexpr bool operator==( const unexpected_type<Error>& lhs,
+                               const expected<T,Error>& rhs );
+    template<typename T, typename Error>
+    constexpr bool operator!=( const expected<T,Error>& lhs,
+                               const unexpected_type<Error>& rhs);
+    template<typename T, typename Error>
+    constexpr bool operator!=( const unexpected_type<Error>& lhs,
+                               const expected<T,Error>& rhs );
+    template<typename T, typename Error>
+    constexpr bool operator<( const expected<T,Error>& lhs,
+                              const unexpected_type<Error>& rhs );
+    template<typename T, typename Error>
+    constexpr bool operator<( const unexpected_type<Error>& lhs,
+                              const expected<T,Error>& rhs );
+    template<typename T, typename Error>
+    constexpr bool operator<=( const expected<T,Error>& lhs,
+                               const unexpected_type<Error>& rhs );
+    template<typename T, typename Error>
+    constexpr bool operator<=( const unexpected_type<Error>& lhs,
+                               const expected<T,Error>& rhs );
+    template<typename T, typename Error>
+    constexpr bool operator>( const expected<T,Error>& lhs,
+                              const unexpected_type<Error>& rhs);
+    template<typename T, typename Error>
+    constexpr bool operator>( const unexpected_type<Error>& lhs,
+                              const expected<T,Error>& rhs ) ;
+    template<typename T, typename Error>
+    constexpr bool operator>=( const expected<T,Error>& lhs,
+                               const unexpected_type<Error>& rhs );
+    template<typename T, typename Error>
+    constexpr bool operator>=( const unexpected_type<Error>& lhs,
+                               const expected<T,Error>& rhs );
+
+    // X.Z.11, Specialized algorithms
+    template<typename T, typename Error>
+    void swap( expected<T,Error>& lhs, expected<T,Error>& rhs );
+
+    // X.Z.12, Factories
+
+    template<typename T>
+    constexpr expected<std::decay_t<T>> make_expected( T&& v );
+
+    expected<void> make_expected();
+
+  } // namespace stl
+} // namespace bit
+
+#include "detail/expected.inl"
+
+#endif /* BIT_STL_UTILITIES_EXPECTED_HPP */

--- a/include/bit/stl/utilities/tribool.hpp
+++ b/include/bit/stl/utilities/tribool.hpp
@@ -147,12 +147,10 @@ namespace bit {
     /// \param rhs the right entry
     /// \return \c true if \p lhs has the same state as \p rhs
     constexpr bool operator==( const tribool& lhs, const tribool& rhs ) noexcept;
-
-    /// \copydoc operator==( const tribool&, const tribool& )
     constexpr bool operator==( indeterminate_t, const tribool& rhs ) noexcept;
-
-    /// \copydoc operator==( const tribool&, const tribool& )
     constexpr bool operator==( const tribool& lhs, indeterminate_t ) noexcept;
+    constexpr bool operator==( const tribool& lhs, bool rhs ) noexcept;
+    constexpr bool operator==( bool lhs, const tribool& rhs ) noexcept;
 
     /// \brief Equality comparison between two tribooleans
     ///
@@ -160,12 +158,10 @@ namespace bit {
     /// \param rhs the right entry
     /// \return \c true if \p lhs has the same state as \p rhs
     constexpr bool operator!=( const tribool& lhs, const tribool& rhs ) noexcept;
-
-    /// \copydoc operator!=( const tribool&, const tribool& )
     constexpr bool operator!=( indeterminate_t, const tribool& rhs ) noexcept;
-
-    /// \copydoc operator!=( const tribool&, const tribool& )
     constexpr bool operator!=( const tribool& lhs, indeterminate_t ) noexcept;
+    constexpr bool operator!=( const tribool& lhs, bool rhs ) noexcept;
+    constexpr bool operator!=( bool lhs, const tribool& rhs ) noexcept;
 
     constexpr tribool operator && ( const tribool& lhs, const tribool& rhs) noexcept;
     constexpr tribool operator || ( const tribool& lhs, const tribool& rhs) noexcept;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,7 @@ set(sources
       bit/stl/utilities/delegate.test.cpp
       bit/stl/utilities/lazy.test.cpp
       bit/stl/utilities/tribool.test.cpp
+      bit/stl/utilities/expected.test.cpp
 
       # containers
       bit/stl/containers/array_view.test.cpp

--- a/test/bit/stl/utilities/expected.test.cpp
+++ b/test/bit/stl/utilities/expected.test.cpp
@@ -1,0 +1,134 @@
+/**
+ * \file expected.test.cpp
+ *
+ * \brief TODO: Add description
+ *
+ * \author Matthew Rodusek (matthew.rodusek@gmail.com)
+ */
+#include <bit/stl/utilities/expected.hpp>
+
+#include <catch.hpp>
+
+#include <system_error>
+
+//=============================================================================
+// expected<T,E>
+//=============================================================================
+
+//-----------------------------------------------------------------------------
+// Constructors / Assignment
+//-----------------------------------------------------------------------------
+
+TEST_CASE("expected::expected()")
+{
+  auto expect = bit::stl::expected<int>();
+
+  SECTION("Default-constructs underlying type T")
+  {
+    REQUIRE( expect.has_value() );
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+TEST_CASE("expected::expected( const expected& )")
+{
+  SECTION("Contains Value")
+  {
+    auto expect = bit::stl::expected<int>(5);
+    auto copy = expect;
+
+    SECTION("Copy contains same value")
+    {
+      REQUIRE( *copy == *expect );
+    }
+    SECTION("Calls underlying value's copy constructor")
+    {
+      // TODO: Check that the copy constructor is called
+    }
+    SECTION("Copied expected contains a value")
+    {
+      REQUIRE( copy.has_value() );
+    }
+  }
+
+  SECTION("Contains Error")
+  {
+    auto unexpect = bit::stl::make_unexpected<std::error_condition>( std::errc::address_family_not_supported );
+    auto expect = bit::stl::expected<int>( unexpect );
+    auto copy = expect;
+
+    SECTION("Copy contains same error")
+    {
+      REQUIRE( copy.error() == expect.error() );
+    }
+    SECTION("Calls underlying error's copy constructor")
+    {
+      // TODO: Check that the copy constructor is called
+    }
+    SECTION("Copied expected contains an error")
+    {
+      REQUIRE( copy.has_error() );
+    }
+  }
+
+  SECTION("Contains Nothing")
+  {
+    // TODO: Trigger valueless_by_exception and ensure state copies over
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+TEST_CASE("expected::expected( expected&& )")
+{
+  SECTION("Contains Value")
+  {
+    auto expect = bit::stl::expected<int>(5);
+    auto copy = expect;
+    auto move = std::move(expect);
+
+    SECTION("Copy contains same value")
+    {
+      REQUIRE( *copy == *move );
+    }
+    SECTION("Calls underlying value's move constructor")
+    {
+      // TODO: Check that the move constructor is called
+    }
+    SECTION("Moved expected contains a value")
+    {
+      REQUIRE( move.has_value() );
+    }
+  }
+
+  SECTION("Contains Error")
+  {
+    auto unexpect = bit::stl::make_unexpected<std::error_condition>( std::errc::address_family_not_supported );
+    auto expect = bit::stl::expected<int>( unexpect );
+    auto copy = expect;
+    auto move = std::move(expect);
+
+    SECTION("Copy contains same error")
+    {
+      REQUIRE( copy.error() == move.error() );
+    }
+    SECTION("Calls underlying error's move constructor")
+    {
+      // TODO Check that the move constructor is called
+    }
+    SECTION("Moved expected contains an error")
+    {
+      REQUIRE( move.has_error() );
+    }
+  }
+
+  SECTION("Contains Nothing")
+  {
+    // TODO: Trigger valueless_by_exception and ensure state copies over
+  }
+}
+
+//-----------------------------------------------------------------------------
+//
+//-----------------------------------------------------------------------------


### PR DESCRIPTION
Implemented `expected<T,E>` 

This introduces the `expected<T>` type from the [standards proposals](http://open-std.org/JTC1/SC22/WG21/docs/papers/2017/p0323r2.pdf) with a few notable alterations:

- `expected` is implemented more in-terms of `variant`'s API. This adds a `valueless_by_exception` state
  - This means it is not a true monadic type
  - This is to account for the incoherent behavior of `emplace(...)`, where `emplace` may only sometimes construct the type; and other times assign the type.
- `unexpected_type` has in-place construction options, rather than strictly copy/move construction
- `expected::error()` and `expected::get_unexpected()` may throw if they do not contain an error state. 
  - This behavior is more coherent than producing undefined behavior. 
  - This is more coherent with `expected::value()` which may be throwing; though comes at a slight penalty of a check. This penalty is for the less-common case, however.
- Specialization of `bad_expected_access<void>`, thrown when accessing an `expected` in a `valueless_by_exception` state