### PR TITLE
Added tests for implicit and explicit constructibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,13 +68,17 @@ set(headers
   include/bit/stl/traits/composition/nonesuch.hpp
   include/bit/stl/traits/composition/sfinae.hpp
   include/bit/stl/traits/composition/size_constant.hpp
+  include/bit/stl/traits/composition/type_list.hpp
   include/bit/stl/traits/composition/void_t.hpp
   include/bit/stl/traits/properties/arity.hpp
   include/bit/stl/traits/properties/function_argument.hpp
   include/bit/stl/traits/properties/index_of_type.hpp
   include/bit/stl/traits/properties/is_const_member_function_pointer.hpp
   include/bit/stl/traits/properties/is_cv_member_function_pointer.hpp
+  include/bit/stl/traits/properties/is_explicitly_constructible.hpp
   include/bit/stl/traits/properties/is_explicitly_convertible.hpp
+  include/bit/stl/traits/properties/is_implicitly_constructible.hpp
+  include/bit/stl/traits/properties/is_implicitly_convertible.hpp
   include/bit/stl/traits/properties/is_volatile_member_function_pointer.hpp
   include/bit/stl/traits/properties/nth_type.hpp
   include/bit/stl/traits/properties/pointer_rank.hpp

--- a/include/bit/stl/traits/composition/type_list.hpp
+++ b/include/bit/stl/traits/composition/type_list.hpp
@@ -1,0 +1,27 @@
+/**
+ * \file type_list.hpp
+ *
+ * \brief This header contains a generic metaprogramming utility for storing a
+ *        sequence of types in a single type.
+ *
+ * \author Matthew Rodusek (matthew.rodusek@gmail.com)
+ */
+#ifndef BIT_STL_TRAITS_COMPOSITION_TYPE_LIST_HPP
+#define BIT_STL_TRAITS_COMPOSITION_TYPE_LIST_HPP
+
+namespace bit {
+  namespace stl {
+
+    /// \brief A utility metafunction for encoding a sequence of types into a
+    ///        single unique type.
+    ///
+    /// This is used for packing multiple types into one as a template argument,
+    /// for expansion later. This can be used to support multiple variadic sets
+    /// in a single template.
+    template<typename...Types>
+    struct type_list{};
+
+  } // namespace stl
+} // namespace bit
+
+#endif /* BIT_STL_TRAITS_COMPOSITION_TYPE_LIST_HPP */

--- a/include/bit/stl/traits/properties/is_explicitly_constructible.hpp
+++ b/include/bit/stl/traits/properties/is_explicitly_constructible.hpp
@@ -1,0 +1,47 @@
+/**
+ * \file is_explicitly_constructible.hpp
+ *
+ * \brief This header contains the definitions for a type-trait that determines
+ *        explicit constructibility
+ *
+ * \author Matthew Rodusek (matthew.rodusek@gmail.com)
+ */
+#ifndef BIT_STL_TRAITS_PROPERTIES_IS_EXPLICITLY_CONSTRUCTIBLE_HPP
+#define BIT_STL_TRAITS_PROPERTIES_IS_EXPLICITLY_CONSTRUCTIBLE_HPP
+
+#include "../composition/bool_constant.hpp"
+#include "../composition/type_list.hpp"
+#include "../composition/void_t.hpp"
+
+#include <type_traits> // std::declval
+
+namespace bit {
+  namespace stl {
+    namespace detail {
+
+      template<typename T, typename TypeList, typename = void>
+      struct is_explicitly_constructible_impl : std::false_type {};
+
+      template<typename T, typename...Args>
+      struct is_explicitly_constructible_impl<T,type_list<Args...>,void_t<
+        decltype(T(std::declval<Args>()...))
+      >> : true_type{};
+
+    } // namespace detail
+
+    /// \brief Type trait to determine whether a type is explicitly
+    ///        constructible from a given set of arguments
+    ///
+    /// The result is aliased as \c ::value
+    template<typename T, typename...Args>
+    struct is_explicitly_constructible
+      : detail::is_explicitly_constructible_impl<T, type_list<Args...>>{};
+
+    /// \brief Helper utility to extract is_explicitly_constructible::type
+    template<typename T, typename...Args>
+    constexpr bool is_explicitly_constructible_v = is_explicitly_constructible<T,Args...>::value;
+
+  } // namespace stl
+} // namespace bit
+
+#endif /* BIT_STL_TRAITS_PROPERTIES_IS_EXPLICITLY_CONSTRUCTIBLE_HPP */

--- a/include/bit/stl/traits/properties/is_implicitly_constructible.hpp
+++ b/include/bit/stl/traits/properties/is_implicitly_constructible.hpp
@@ -1,0 +1,56 @@
+/**
+ * \file is_implicitly_constructible.hpp
+ *
+ * \brief This header contains the definitions for a type-trait that determines
+ *        implicit constructibility
+ *
+ * \author Matthew Rodusek (matthew.rodusek@gmail.com)
+ */
+#ifndef BIT_STL_TRAITS_PROPERTIES_IS_IMPLICITLY_CONSTRUCTIBLE_HPP
+#define BIT_STL_TRAITS_PROPERTIES_IS_IMPLICITLY_CONSTRUCTIBLE_HPP
+
+#include "../composition/bool_constant.hpp"
+#include "../composition/type_list.hpp"
+#include "../composition/void_t.hpp"
+
+#include <type_traits> // std::declval
+
+namespace bit {
+  namespace stl {
+    namespace detail {
+
+      template<typename T>
+      struct is_implicitly_constructible_dummy
+      {
+        static void test( T );
+      };
+
+      template<typename T, typename TypeList, typename = void>
+      struct is_implicitly_constructible_impl : false_type{};
+
+      template<typename T, typename...Args>
+      struct is_implicitly_constructible_impl<T,type_list<Args...>,void_t<
+        decltype( is_implicitly_constructible_dummy<T>::test({ std::declval<Args>()... }) )
+      >> : true_type{};
+    } // namespace detail
+
+    /// \brief Type trait to determine if T is implicitly constructible with
+    ///        braced initialization.
+    ///
+    /// \note Implicit construction is braced-initialization construction
+    ///       without specifying the type being constructed. This means that
+    ///       narrowing may occur if integral types are not matched correctly
+    ///
+    /// The result is aliased as \c ::value
+    template<typename T, typename...Args>
+    struct is_implicitly_constructible
+      : detail::is_implicitly_constructible_impl<T,type_list<Args...>>{};
+
+    /// \brief Helper utility to extract is_implicitly_constructible::type
+    template<typename T, typename...Args>
+    constexpr bool is_implicitly_constructible_v = is_implicitly_constructible<T,Args...>::value;
+
+  } // namespace stl
+} // namespace bit
+
+#endif /* BIT_STL_TRAITS_PROPERTIES_IS_IMPLICITLY_CONSTRUCTIBLE_HPP */

--- a/include/bit/stl/traits/properties/is_implicitly_convertible.hpp
+++ b/include/bit/stl/traits/properties/is_implicitly_convertible.hpp
@@ -1,0 +1,61 @@
+/**
+ * \file is_implicitly_convertible.hpp
+ *
+ * \brief This header defines a type-trait for determining whether a type is
+ *        implicitly convertible to another type
+ *
+ * \author Matthew Rodusek (matthew.rodusek@gmail.com)
+ */
+#ifndef BIT_STL_TRAITS_PROPERTIES_IS_IMPLICITLY_CONVERTIBLE_HPP
+#define BIT_STL_TRAITS_PROPERTIES_IS_IMPLICITLY_CONVERTIBLE_HPP
+
+#include "../composition/bool_constant.hpp"
+#include "../composition/void_t.hpp"
+
+#include <type_traits> // std::declval
+
+namespace bit {
+  namespace stl {
+    namespace detail {
+
+      template<typename T>
+      struct is_implicitly_convertible_dummy
+      {
+        static void test( T );
+      };
+
+      template<typename From, typename To, typename = void>
+      struct is_implicitly_convertible_impl : false_type{};
+
+      template<typename From, typename To>
+      struct is_implicitly_convertible_impl<From,To,void_t<
+        decltype( is_implicitly_convertible_dummy<To>::test( std::declval<From>() ) )
+      >> : true_type{};
+    } // namespace detail
+
+    /// \brief Type trait to determine if From is implicitly convertible to
+    ///        To
+    ///
+    /// A type is considered implicitly convertible if the following expression
+    /// is well-formed:
+    ///
+    /// \code
+    /// To test(){ return std::declval<From>(); }
+    /// \endcode
+    ///
+    /// For the purpose of the above illustration, std::declval is not
+    /// considered ODR-used.
+    ///
+    /// The result is aliased as \c ::value
+    template<typename From, typename To>
+    struct is_implicitly_convertible
+      : detail::is_implicitly_convertible_impl<From,To>{};
+
+    /// \brief Helper utility to extract is_implicitly_convertible::type
+    template<typename From, typename To>
+    constexpr bool is_implicitly_convertible_v = is_implicitly_convertible<From,To>::value;
+
+  } // namespace stl
+} // namespace bit
+
+#endif /* BIT_STL_TRAITS_PROPERTIES_IS_IMPLICITLY_CONVERTIBLE_HPP */


### PR DESCRIPTION
Similar to std::is_constructible and std::is_convertible,
these tests determine whether types can be constructed from
implicit vs explicit expressions (e.g. requiring manual casting
or constructor calls, vs allowing the type system to convert it)