### PR TITLE
Remove delegate::bind with pointer argument

### DIFF
--- a/include/bit/stl/utilities/delegate.hpp
+++ b/include/bit/stl/utilities/delegate.hpp
@@ -18,9 +18,9 @@
 namespace bit {
   namespace stl {
 
-    ////////////////////////////////////////////////////////////////////////////
-    /// \brief This class is for a lightweight way of managing function callbacks
-    ///        without requiring heap allocations.
+    ///////////////////////////////////////////////////////////////////////////
+    /// \brief This class is for a lightweight way of managing function
+    ///        callbacks without requiring heap allocations.
     ///
     /// The syntax is a little off as a result, requiring a call to
     /// Delegate::bind.
@@ -37,15 +37,15 @@ namespace bit {
     /// \endcode
     ///
     /// \tparam Function signature and return type
-    ////////////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////
     template<typename Fn> class delegate;
 
     template<typename R, typename...Types>
     class delegate<R(Types...)> final
     {
-      //-----------------------------------------------------------------------------
+      //-----------------------------------------------------------------------
       // Public Member Types
-      //-----------------------------------------------------------------------------
+      //-----------------------------------------------------------------------
     public:
 
       using return_type        = R;
@@ -57,17 +57,17 @@ namespace bit {
       template<class C>
       using const_member_function_type = return_type (C::*)(Types...) const;
 
-      //-----------------------------------------------------------------------------
+      //-----------------------------------------------------------------------
       // Constructor / Destructor
-      //-----------------------------------------------------------------------------
+      //-----------------------------------------------------------------------
     public:
 
       /// \brief Constructs an unbound delegate
       constexpr delegate() noexcept;
 
-      //-----------------------------------------------------------------------------
+      //-----------------------------------------------------------------------
       // Function Binding
-      //-----------------------------------------------------------------------------
+      //-----------------------------------------------------------------------
     public:
 
       /// \brief Binds a free function to this delegate
@@ -84,9 +84,6 @@ namespace bit {
       /// \tparam member_function The pointer to member function to bind
       /// \param instance the instance to call the member function on
       template <class C, member_function_type<C> member_function>
-      constexpr void bind( C* instance ) noexcept;
-
-      template <class C, member_function_type<C> member_function>
       constexpr void bind( C& instance ) noexcept;
       /// \}
 
@@ -97,21 +94,15 @@ namespace bit {
       /// \tparam member_function The pointer to member function to bind
       /// \param instance the instance to call the member function on
       template <class C, const_member_function_type<C> member_function>
-      constexpr void bind( const C* instance ) noexcept;
-
-      template <class C, const_member_function_type<C> member_function>
       constexpr void bind( const C& instance ) noexcept;
-
-      template <class C, const_member_function_type<C> member_function>
-      constexpr void cbind( const C* instance ) noexcept;
 
       template <class C, const_member_function_type<C> member_function>
       constexpr void cbind( const C& instance ) noexcept;
       /// \}
 
-      //-----------------------------------------------------------------------------
+      //-----------------------------------------------------------------------
       // Queries
-      //-----------------------------------------------------------------------------
+      //-----------------------------------------------------------------------
     public:
 
       /// \brief Is this Delegate bound?
@@ -122,9 +113,9 @@ namespace bit {
       /// \brief Returns true if this delegate is bound
       constexpr explicit operator bool() const noexcept;
 
-      //-----------------------------------------------------------------------------
+      //-----------------------------------------------------------------------
       // Invocation
-      //-----------------------------------------------------------------------------
+      //-----------------------------------------------------------------------
     public:
 
       /// \brief Invokes the bound function
@@ -138,17 +129,17 @@ namespace bit {
       template<typename...Args, typename = std::enable_if_t<is_invocable<R(Types...),Args...>::value>>
       constexpr return_type operator()( Args&&...args ) const;
 
-      //-----------------------------------------------------------------------------
+      //-----------------------------------------------------------------------
       // Private Member Types
-      //-----------------------------------------------------------------------------
+      //-----------------------------------------------------------------------
     private:
 
       using internal_function_type = return_type(*)(void*, Types...);
       using stub_type              = std::pair<void*, internal_function_type>;
 
-      //-----------------------------------------------------------------------------
+      //-----------------------------------------------------------------------
       // Private Members
-      //-----------------------------------------------------------------------------
+      //-----------------------------------------------------------------------
     private:
 
       stub_type m_delegate_stub; ///< The internal stub for this delegate
@@ -172,19 +163,6 @@ namespace bit {
     bool operator<=(const delegate<Fn>& lhs, const delegate<Fn>& rhs);
     template<typename Fn>
     bool operator>=(const delegate<Fn>& lhs, const delegate<Fn>& rhs);
-
-    //------------------------------------------------------------------------
-    // Make Utilities
-    //------------------------------------------------------------------------
-//
-//    template<typename Sig, function_t<Sig> function>
-//    delegate<Sig> make_delegate() noexcept;
-//
-//    template<typename T, typename Sig, member_function_t<T,Sig> member_function>
-//    delegate<Sig> make_delegate( T& instance ) noexcept;
-//
-//    template<typename T, typename Sig, member_function_t<T,Sig> member_function>
-//    delegate<Sig> make_delegate( T* instance ) noexcept;
 
 #if __cplusplus >= 201703L
 

--- a/include/bit/stl/utilities/detail/delegate.inl
+++ b/include/bit/stl/utilities/detail/delegate.inl
@@ -1,9 +1,9 @@
 #ifndef BIT_STL_UTILITIES_DETAIL_DELEGATE_INL
 #define BIT_STL_UTILITIES_DETAIL_DELEGATE_INL
 
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Constructor
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 
 template<typename R, typename ... Types>
 constexpr bit::stl::delegate<R(Types...)>::delegate()
@@ -13,9 +13,9 @@ constexpr bit::stl::delegate<R(Types...)>::delegate()
 
 }
 
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Function Binding
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 
 template<typename R, typename ... Types>
 template<R (*function)(Types...)>
@@ -31,21 +31,7 @@ inline constexpr void
   m_delegate_stub.second = callback;
 }
 
-//----------------------------------------------------------------------------
-
-template<typename R, typename ... Types>
-template<typename C, R (C::*member_function)(Types...)>
-inline constexpr void
-  bit::stl::delegate<R(Types...)>::bind( C* instance )
-  noexcept
-{
-  const auto callback = [](void* ptr, Types...args )
-  {
-    return (static_cast<C*>(ptr)->*member_function)(std::forward<Types>(args)...);
-  };
-  m_delegate_stub.first  = instance;
-  m_delegate_stub.second = callback;
-}
+//-----------------------------------------------------------------------------
 
 template<typename R, typename ... Types>
 template<typename C, R (C::*member_function)(Types...)>
@@ -53,15 +39,20 @@ inline constexpr void
   bit::stl::delegate<R(Types...)>::bind( C& instance )
   noexcept
 {
-  bind<C,member_function>( std::addressof(instance) );
+  const auto callback = [](void* ptr, Types...args )
+  {
+    return (static_cast<C*>(ptr)->*member_function)(std::forward<Types>(args)...);
+  };
+  m_delegate_stub.first  = static_cast<void*>(std::addressof(instance));
+  m_delegate_stub.second = callback;
 }
 
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 
 template<typename R, typename ... Types>
 template<typename C, R (C::*member_function)(Types...) const>
 inline constexpr void
-  bit::stl::delegate<R(Types...)>::bind( const C* instance )
+  bit::stl::delegate<R(Types...)>::bind( const C& instance )
   noexcept
 {
   cbind<C,member_function>( instance );
@@ -70,33 +61,15 @@ inline constexpr void
 template<typename R, typename ... Types>
 template<typename C, R (C::*member_function)(Types...) const>
 inline constexpr void
-  bit::stl::delegate<R(Types...)>::bind( const C& instance )
-  noexcept
-{
-  cbind<C,member_function>( std::addressof(instance) );
-}
-
-template<typename R, typename ... Types>
-template<typename C, R (C::*member_function)(Types...) const>
-inline constexpr void
-  bit::stl::delegate<R(Types...)>::cbind( const C* instance )
+  bit::stl::delegate<R(Types...)>::cbind( const C& instance )
   noexcept
 {
   const auto callback = [](void* ptr, Types...args )
   {
     return (static_cast<const C*>(ptr)->*member_function)(std::forward<Types>(args)...);
   };
-  m_delegate_stub.first  = const_cast<C*>(instance); // needed for const
+  m_delegate_stub.first  = const_cast<C*>( std::addressof(instance) ); // needed for const
   m_delegate_stub.second = callback;
-}
-
-template<typename R, typename ... Types>
-template<typename C, R (C::*member_function)(Types...) const>
-inline constexpr void
-  bit::stl::delegate<R(Types...)>::cbind( const C& instance )
-  noexcept
-{
-  cbind<C,member_function>( std::addressof(instance) );
 }
 
 //----------------------------------------------------------------------------
@@ -179,33 +152,5 @@ inline bool bit::stl::operator>=(const delegate<Fn>& lhs, const delegate<Fn>& rh
 {
   return !(lhs < rhs);
 }
-
-//----------------------------------------------------------------------------
-// Make Utilities
-//----------------------------------------------------------------------------
-
-//template<typename Sig, bit::stl::function_t<Sig> function>
-//bit::stl::delegate<Sig> bit::stl::make_delegate()
-//  noexcept
-//{
-//  auto result = delegate<Sig>();
-//  return result.bind<function>();
-//}
-//
-//template<typename T, typename Sig, bit::stl::member_function_t<T,Sig> member_function>
-//bit::stl::delegate<Sig> bit::stl::make_delegate( T& instance )
-//  noexcept
-//{
-//  auto result = delegate<Sig>();
-//  return result.bind<member_function>( instance );
-//}
-//
-//template<typename T, typename Sig, bit::stl::member_function_t<T,Sig> member_function>
-//bit::stl::delegate<Sig> bit::stl::make_delegate( T* instance )
-//  noexcept
-//{
-//  auto result = delegate<Sig>();
-//  return result.bind<member_function>( instance );
-//}
 
 #endif /* BIT_STL_UTILITIES_DETAIL_DELEGATE_INL */

--- a/test/bit/stl/utilities/delegate.test.cpp
+++ b/test/bit/stl/utilities/delegate.test.cpp
@@ -66,14 +66,14 @@ TEST_CASE("delegate::bind()", "[member function]")
   }
 }
 
-TEST_CASE("delegate::bind( T* )", "[member function]")
+TEST_CASE("delegate::bind( T& )", "[member function]")
 {
   SECTION("Binds non-const member function")
   {
     bit::stl::delegate<int(int)> delegate;
     DummyClass              dummy(10);
 
-    delegate.bind<DummyClass,&DummyClass::non_const_function>(&dummy);
+    delegate.bind<DummyClass,&DummyClass::non_const_function>(dummy);
     REQUIRE( delegate.is_bound() );
   }
 
@@ -82,7 +82,7 @@ TEST_CASE("delegate::bind( T* )", "[member function]")
     bit::stl::delegate<int(int)> delegate;
     const DummyClass        dummy(10);
 
-    delegate.bind<DummyClass,&DummyClass::const_function>(&dummy);
+    delegate.bind<DummyClass,&DummyClass::const_function>(dummy);
     REQUIRE( delegate.is_bound() );
   }
 }
@@ -145,7 +145,7 @@ TEST_CASE("delegate::invoke(Args&&...)", "[member function]")
     bit::stl::delegate<int(int)> delegate;
     DummyClass              dummy(10);
 
-    delegate.bind<DummyClass,&DummyClass::non_const_function>(&dummy);
+    delegate.bind<DummyClass,&DummyClass::non_const_function>(dummy);
 
     REQUIRE( delegate.invoke(5) == 15 );
   }
@@ -155,7 +155,7 @@ TEST_CASE("delegate::invoke(Args&&...)", "[member function]")
     bit::stl::delegate<int(int)> delegate;
     const DummyClass        dummy(10);
 
-    delegate.bind<DummyClass,&DummyClass::const_function>(&dummy);
+    delegate.bind<DummyClass,&DummyClass::const_function>(dummy);
 
     REQUIRE( delegate.invoke(5) == 15 );
   }


### PR DESCRIPTION
Delegate supports 2 overloads for binding member functions;
one that supports a raw pointer to the entity being bound,
and the other that accepts a reference. There is no distinction
between the two, but there is an implicit requirement that the
pointer always not be null, since otherwise invoking the delegate
would lead to undefined behaviour (invoking null pointer).

This is considered an API bug. To fix this, the pointer overloads
have been removed in favor of just the reference ones, which
guarantee non-nullability.