### PR TITLE
Add exclusive_ptr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,7 @@ set(headers
 
   # memory
   include/bit/stl/memory/allocator_deleter.hpp
+  include/bit/stl/memory/exclusive_ptr.hpp
   include/bit/stl/memory/clone_ptr.hpp
   include/bit/stl/memory/fat_ptr.hpp
   include/bit/stl/memory/memory.hpp

--- a/include/bit/stl/memory/detail/exclusive_ptr.inl
+++ b/include/bit/stl/memory/detail/exclusive_ptr.inl
@@ -1,0 +1,738 @@
+#ifndef BIT_STL_MEMORY_DETAIL_EXCLUSIVE_PTR_INL
+#define BIT_STL_MEMORY_DETAIL_EXCLUSIVE_PTR_INL
+
+
+//=============================================================================
+// exclusive_ptr_control_block
+//=============================================================================
+
+class bit::stl::detail::exclusive_ptr_control_block
+{
+public:
+
+  virtual void destroy() = 0;
+
+  virtual void* get_deleter( const std::type_info& ) noexcept = 0;
+};
+
+//=============================================================================
+// exclusive_ptr_emplace
+//=============================================================================
+
+template<typename T, typename Allocator>
+class bit::stl::detail::exclusive_ptr_emplace
+  : public bit::stl::detail::exclusive_ptr_control_block
+{
+public:
+
+  template<typename...Args>
+  exclusive_ptr_emplace( Allocator alloc, Args&&...args );
+
+  void destroy() override;
+
+  void* get_deleter( const std::type_info& info ) noexcept override;
+
+  T* get() noexcept;
+
+private:
+
+  ::bit::stl::compressed_tuple<T, Allocator> m_storage;
+};
+
+template<typename T, typename Allocator>
+template<typename...Args>
+inline bit::stl::detail::exclusive_ptr_emplace<T,Allocator>
+  ::exclusive_ptr_emplace( Allocator alloc, Args&&...args )
+  : m_storage( std::piecewise_construct,
+               std::forward_as_tuple(std::forward<Args>(args)...),
+               std::forward_as_tuple(alloc) )
+{
+
+}
+
+template<typename T, typename Allocator>
+inline void bit::stl::detail::exclusive_ptr_emplace<T,Allocator>::destroy()
+{
+  using control_block = exclusive_ptr_emplace<T,Allocator>;
+  using atraits   = typename std::allocator_traits<Allocator>::template rebind_traits<control_block>;
+  using ptraits   = std::pointer_traits<typename atraits::pointer>;
+  using allocator = typename atraits::allocator_type;
+
+  using bit::stl::get;
+
+  auto& value = get<0>(m_storage);
+  auto& alloc = get<1>(m_storage);
+
+  // Create allocator to deallocate this control block
+  allocator control_block_allocator(alloc);
+
+  // Destroy the allocator and the underlying type
+  alloc.~Allocator();
+  value.~T();
+
+  // deallocate the memory
+  control_block_allocator.deallocate( ptraits::pointer_to(*this), 1);
+}
+
+template<typename T, typename Allocator>
+inline void* bit::stl::detail::exclusive_ptr_emplace<T,Allocator>
+  ::get_deleter( const std::type_info& info )
+  noexcept
+{
+  return nullptr;
+}
+
+template<typename T, typename Allocator>
+inline T* bit::stl::detail::exclusive_ptr_emplace<T,Allocator>::get()
+  noexcept
+{
+  using bit::stl::get;
+
+  return std::addressof(bit::stl::get<0>(m_storage));
+}
+
+//=============================================================================
+// exclusive_ptr_pointer
+//=============================================================================
+
+template<typename T, typename Deleter, typename Allocator>
+class bit::stl::detail::exclusive_ptr_pointer
+  : public bit::stl::detail::exclusive_ptr_control_block
+{
+public:
+
+  exclusive_ptr_pointer( T* pointer,
+                         const Deleter& deleter,
+                         const Allocator& allocator );
+
+  void destroy() override;
+
+  void* get_deleter( const std::type_info& ) noexcept override;
+
+  T* get() noexcept;
+
+private:
+
+  ::bit::stl::compressed_tuple<T, Deleter, Allocator> m_storage;
+};
+
+template<typename T, typename Deleter, typename Allocator>
+inline bit::stl::detail::exclusive_ptr_pointer<T,Deleter,Allocator>
+  ::exclusive_ptr_pointer( T* pointer,
+                           const Deleter& deleter,
+                           const Allocator& allocator )
+  : m_storage( std::piecewise_construct,
+               std::forward_as_tuple(pointer),
+               std::forward_as_tuple(deleter),
+               std::forward_as_tuple(allocator) )
+{
+
+}
+
+template<typename T, typename Deleter, typename Allocator>
+inline void bit::stl::detail::exclusive_ptr_pointer<T,Deleter,Allocator>
+  ::destroy()
+{
+  using control_block = exclusive_ptr_pointer<T,Deleter,Allocator>;
+  using atraits   = typename std::allocator_traits<Allocator>::template rebind_traits<control_block>;
+  using ptraits   = std::pointer_traits<typename atraits::pointer>;
+  using allocator = typename atraits::allocator_type;
+
+  // Delete the underlying type, the allocator, and this control block
+
+  using bit::stl::get;
+
+  auto& pointer = get<0>(m_storage);
+  auto& deleter = get<1>(m_storage);
+  auto& alloc   = get<2>(m_storage);
+
+  allocator control_block_allocator(alloc);
+
+  // Call the deleter with the specified pointer
+  deleter(pointer);
+
+  // Delete the deleter and allocator
+  deleter.~Deleter();
+  alloc.~Allocator();
+
+  // Deallocate the entire block
+  control_block_allocator.deallocate( ptraits::pointer_to(*this), 1);
+}
+
+template<typename T, typename Deleter, typename Allocator>
+inline void* bit::stl::detail::exclusive_ptr_pointer<T,Deleter,Allocator>
+  ::get_deleter( const std::type_info& info )
+  noexcept
+{
+  using bit::stl::get;
+
+  if( typeid(Deleter) == info ) {
+    return std::addressof( get<1>(m_storage) );
+  }
+  return nullptr;
+}
+
+template<typename T, typename Deleter, typename Allocator>
+inline T* bit::stl::detail::exclusive_ptr_pointer<T,Deleter,Allocator>::get()
+  noexcept
+{
+  using bit::stl::get;
+
+  return std::addressof( get<0>(m_storage) );
+}
+
+//=============================================================================
+// casts
+//=============================================================================
+
+template<typename T, typename U>
+inline bit::stl::exclusive_ptr<T>
+  bit::stl::detail::static_pointer_cast( exclusive_ptr<U>&& other )
+{
+  auto p = static_cast<T*>(other.m_ptr);
+  auto c = other.m_control_block;
+
+  other.m_ptr           = nullptr;
+  other.m_control_block = nullptr;
+
+  return { typename exclusive_ptr<T>::ctor_tag{}, c, p };
+}
+
+template<typename T, typename U>
+inline bit::stl::exclusive_ptr<T>
+  bit::stl::detail::dynamic_pointer_cast( exclusive_ptr<U>&& other )
+{
+  if( auto p = dynamic_cast<T*>(other.m_ptr) )
+  {
+    auto c = other.m_control_block;
+
+    other.m_ptr           = nullptr;
+    other.m_control_block = nullptr;
+
+    return { typename exclusive_ptr<T>::ctor_tag{}, c, p };
+  }
+  return nullptr;
+}
+
+template<typename T, typename U>
+inline bit::stl::exclusive_ptr<T>
+  bit::stl::detail::const_pointer_cast( exclusive_ptr<U>&& other )
+{
+  auto p = const_cast<T*>(other.m_ptr);
+  auto c = other.m_control_block;
+
+  other.m_ptr           = nullptr;
+  other.m_control_block = nullptr;
+
+  return { typename exclusive_ptr<T>::ctor_tag{}, c, p };
+}
+
+template<typename T, typename U>
+inline bit::stl::exclusive_ptr<T>
+  bit::stl::detail::reinterpret_pointer_cast( exclusive_ptr<U>&& other )
+{
+  auto p = reinterpret_cast<T*>(other.m_ptr);
+  auto c = other.m_control_block;
+
+  other.m_ptr           = nullptr;
+  other.m_control_block = nullptr;
+
+  return { typename exclusive_ptr<T>::ctor_tag{}, c, p };
+}
+
+
+//=============================================================================
+// exclusive_ptr
+//=============================================================================
+
+//-----------------------------------------------------------------------------
+// Constructors / Destructor / Assignment
+//-----------------------------------------------------------------------------
+
+template<typename T>
+inline constexpr bit::stl::exclusive_ptr<T>::exclusive_ptr()
+  noexcept
+  : exclusive_ptr( nullptr )
+{
+
+}
+
+template<typename T>
+inline constexpr bit::stl::exclusive_ptr<T>::exclusive_ptr( std::nullptr_t )
+  noexcept
+  : m_control_block(nullptr),
+    m_ptr(nullptr)
+{
+
+}
+
+template<typename T>
+template<typename Y, typename>
+inline bit::stl::exclusive_ptr<T>::exclusive_ptr( Y* ptr )
+  : exclusive_ptr( ptr, std::default_delete<Y>{} )
+{
+
+}
+
+template<typename T>
+template<typename Y, typename Deleter, typename>
+inline bit::stl::exclusive_ptr<T>::exclusive_ptr( Y* ptr, Deleter deleter )
+  : exclusive_ptr( ptr, deleter, std::allocator<void>{} )
+{
+
+}
+
+template<typename T>
+template<typename Deleter>
+inline bit::stl::exclusive_ptr<T>::exclusive_ptr( std::nullptr_t,
+                                                  Deleter )
+  noexcept
+  : exclusive_ptr( nullptr )
+{
+
+}
+
+template<typename T>
+template<typename Y, typename Deleter, typename Allocator, typename>
+inline bit::stl::exclusive_ptr<T>::exclusive_ptr( Y* ptr,
+                                                  Deleter deleter,
+                                                  Allocator alloc )
+{
+  reset( ptr, deleter, alloc );
+}
+
+template<typename T>
+template<typename Deleter, typename Allocator>
+inline bit::stl::exclusive_ptr<T>::exclusive_ptr( std::nullptr_t,
+                                                  Deleter,
+                                                  Allocator )
+  noexcept
+  : exclusive_ptr( nullptr )
+{
+
+}
+
+template<typename T>
+inline bit::stl::exclusive_ptr<T>::exclusive_ptr( exclusive_ptr&& other )
+  noexcept
+  : m_control_block( other.m_control_block ),
+    m_ptr( other.m_ptr )
+{
+  other.m_control_block = nullptr;
+  other.m_ptr = nullptr;
+}
+
+template<typename T>
+template<typename Y, typename>
+inline bit::stl::exclusive_ptr<T>::exclusive_ptr( exclusive_ptr<Y>&& other )
+  noexcept
+  : m_control_block( other.m_control_block ),
+    m_ptr( other.m_ptr )
+{
+  other.m_control_block = nullptr;
+  other.m_ptr = nullptr;
+}
+
+//-----------------------------------------------------------------------
+
+template<typename T>
+inline bit::stl::exclusive_ptr<T>::~exclusive_ptr()
+{
+  reset();
+}
+
+//-----------------------------------------------------------------------
+
+template<typename T>
+bit::stl::exclusive_ptr<T>&
+  bit::stl::exclusive_ptr<T>::operator=( exclusive_ptr&& other )
+  noexcept
+{
+  m_control_block = other.m_control_block;
+  m_ptr      = other.m_ptr;
+
+  other.m_control_block = nullptr;
+  other.m_ptr      = nullptr;
+
+  return (*this);
+}
+
+template<typename T>
+template<typename Y, typename>
+bit::stl::exclusive_ptr<T>&
+  bit::stl::exclusive_ptr<T>::operator=( exclusive_ptr<Y>&& other )
+  noexcept
+{
+  m_control_block = other.m_control_block;
+  m_ptr      = other.m_ptr;
+
+  other.m_control_block = nullptr;
+  other.m_ptr      = nullptr;
+
+  return (*this);
+}
+
+template<typename T>
+bit::stl::exclusive_ptr<T>&
+  bit::stl::exclusive_ptr<T>::operator=( std::nullptr_t other )
+  noexcept
+{
+  reset();
+
+  return (*this);
+}
+
+//-----------------------------------------------------------------------
+// Modifiers
+//-----------------------------------------------------------------------
+
+template<typename T>
+inline void bit::stl::exclusive_ptr<T>::reset()
+  noexcept
+{
+  if( m_control_block ) {
+    m_control_block->destroy();
+    m_control_block = nullptr;
+    m_ptr      = nullptr;
+  }
+}
+
+template<typename T>
+template<typename Y, typename>
+inline void bit::stl::exclusive_ptr<T>::reset( Y* ptr )
+{
+  reset( ptr, std::default_delete<Y>{} );
+}
+
+template<typename T>
+template<typename Y, typename Deleter, typename>
+inline void bit::stl::exclusive_ptr<T>::reset( Y* ptr, Deleter deleter )
+{
+  reset( ptr, deleter, std::allocator<void>{} );
+}
+
+template<typename T>
+template<typename Y, typename Deleter, typename Allocator, typename>
+inline void bit::stl::exclusive_ptr<T>::reset( Y* ptr,
+                                               Deleter deleter,
+                                               Allocator alloc )
+{
+  reset();
+
+  if(ptr) {
+    using control_block = detail::exclusive_ptr_pointer<T,Deleter,Allocator>;
+    using alloc_traits  = typename std::allocator_traits<Allocator>::template rebind_traits<control_block>;
+    using allocator     = typename alloc_traits::allocator_type;
+    using destructor    = allocator_deleter<allocator>;
+
+    allocator alloc2(alloc);
+    destructor d{alloc2,1};
+    std::unique_ptr<control_block,destructor> hold( alloc2.allocate(1), d );
+
+    alloc_traits::construct( alloc2, hold.get(), ptr, deleter, alloc );
+
+    m_ptr = ptr;
+    m_control_block = hold.release();
+  }
+}
+
+//-----------------------------------------------------------------------
+
+template<typename T>
+inline void bit::stl::exclusive_ptr<T>::swap( exclusive_ptr& other )
+  noexcept
+{
+  using std::swap;
+
+  swap(m_control_block, other.m_control_block);
+  swap(m_ptr, other.m_ptr);
+}
+
+//-----------------------------------------------------------------------
+// Observers
+//-----------------------------------------------------------------------
+
+template<typename T>
+inline typename bit::stl::exclusive_ptr<T>::element_type*
+  bit::stl::exclusive_ptr<T>::get()
+  const noexcept
+{
+  return m_ptr;
+}
+
+template<typename T>
+template<typename U, typename>
+inline std::add_lvalue_reference_t<typename bit::stl::exclusive_ptr<T>::element_type>
+  bit::stl::exclusive_ptr<T>::operator[]( std::ptrdiff_t i )
+  noexcept
+{
+  return m_ptr[i];
+}
+
+template<typename T>
+inline std::add_lvalue_reference_t<typename bit::stl::exclusive_ptr<T>::element_type>
+  bit::stl::exclusive_ptr<T>::operator*()
+  const noexcept
+{
+  return (*m_ptr);
+}
+
+template<typename T>
+inline typename bit::stl::exclusive_ptr<T>::element_type*
+  bit::stl::exclusive_ptr<T>::operator->()
+  const noexcept
+{
+  return m_ptr;
+}
+
+template<typename T>
+inline bit::stl::exclusive_ptr<T>::operator bool()
+  const noexcept
+{
+  return m_ptr != nullptr;
+}
+
+template<typename T>
+inline bit::stl::exclusive_ptr<T>::exclusive_ptr( ctor_tag,
+                                                  control_block_type* block,
+                                                  T* ptr )
+  noexcept
+  : m_control_block(block),
+    m_ptr(ptr)
+{
+
+}
+
+//=============================================================================
+// Free Functions
+//=============================================================================
+
+//-----------------------------------------------------------------------------
+// Comparisons
+//-----------------------------------------------------------------------------
+
+template<typename T>
+inline bool bit::stl::operator==( const exclusive_ptr<T>& lhs,
+                                  const exclusive_ptr<T>& rhs )
+  noexcept
+{
+  return lhs.get() == rhs.get();
+}
+
+template<typename T>
+inline bool bit::stl::operator!=( const exclusive_ptr<T>& lhs,
+                                  const exclusive_ptr<T>& rhs )
+  noexcept
+{
+  return lhs.get() != rhs.get();
+}
+
+template<typename T>
+inline bool bit::stl::operator<( const exclusive_ptr<T>& lhs,
+                                 const exclusive_ptr<T>& rhs )
+  noexcept
+{
+  return lhs.get() < rhs.get();
+}
+
+template<typename T>
+inline bool bit::stl::operator>( const exclusive_ptr<T>& lhs,
+                                 const exclusive_ptr<T>& rhs )
+  noexcept
+{
+  return lhs.get() > rhs.get();
+}
+
+template<typename T>
+inline bool bit::stl::operator<=( const exclusive_ptr<T>& lhs,
+                                  const exclusive_ptr<T>& rhs )
+  noexcept
+{
+  return lhs.get() <= rhs.get();
+}
+
+template<typename T>
+inline bool bit::stl::operator>=( const exclusive_ptr<T>& lhs,
+                                  const exclusive_ptr<T>& rhs )
+  noexcept
+{
+  return lhs.get() >= rhs.get();
+}
+
+template<typename T>
+inline bool bit::stl::operator==( const exclusive_ptr<T>& lhs,
+                                  std::nullptr_t ) noexcept
+{
+  return lhs.get() == nullptr;
+}
+
+template<typename T>
+inline bool bit::stl::operator==( std::nullptr_t,
+                                  const exclusive_ptr<T>& rhs )
+  noexcept
+{
+  return nullptr == rhs.get();
+}
+
+template<typename T>
+inline bool bit::stl::operator!=( const exclusive_ptr<T>& lhs,
+                                  std::nullptr_t )
+  noexcept
+{
+  return lhs.get() != nullptr;
+}
+
+template<typename T>
+inline bool bit::stl::operator!=( std::nullptr_t,
+                                  const exclusive_ptr<T>& rhs )
+  noexcept
+{
+  return nullptr != rhs.get();
+}
+
+template<typename T>
+inline bool bit::stl::operator<( const exclusive_ptr<T>& lhs,
+                                 std::nullptr_t )
+  noexcept
+{
+  return false;
+}
+
+template<typename T>
+inline bool bit::stl::operator<( std::nullptr_t,
+                                 const exclusive_ptr<T>& rhs )
+  noexcept
+{
+  return rhs.get() != nullptr;
+}
+
+template<typename T>
+inline bool bit::stl::operator>( const exclusive_ptr<T>& lhs,
+                                 std::nullptr_t )
+  noexcept
+{
+  return lhs.get() != nullptr;
+}
+
+template<typename T>
+inline bool bit::stl::operator>( std::nullptr_t,
+                                 const exclusive_ptr<T>& rhs )
+  noexcept
+{
+  return false;
+}
+
+template<typename T>
+inline bool bit::stl::operator<=( const exclusive_ptr<T>& lhs,
+                                  std::nullptr_t )
+  noexcept
+{
+  return lhs.get() == nullptr;
+}
+
+template<typename T>
+inline bool bit::stl::operator<=( std::nullptr_t,
+                                  const exclusive_ptr<T>& rhs )
+  noexcept
+{
+  return true;
+}
+
+template<typename T>
+inline bool bit::stl::operator>=( const exclusive_ptr<T>& lhs,
+                                  std::nullptr_t )
+  noexcept
+{
+  return true;
+}
+
+template<typename T>
+inline bool bit::stl::operator>=( std::nullptr_t,
+                                  const exclusive_ptr<T>& rhs )
+  noexcept
+{
+  return rhs.get() == nullptr;
+}
+
+//-----------------------------------------------------------------------------
+// Utilities
+//-----------------------------------------------------------------------------
+
+template<typename T>
+inline void bit::stl::swap( exclusive_ptr<T>& lhs, exclusive_ptr<T>& rhs )
+  noexcept
+{
+  lhs.swap(rhs);
+}
+
+//-------------------------------------------------------------------------
+
+template<typename Deleter, typename T>
+inline Deleter* bit::stl::get_deleter( const exclusive_ptr<T>& ptr )
+{
+  return static_cast<Deleter*>( ptr.m_control_block->get_deleter( typeid(T) ) );
+}
+
+//-------------------------------------------------------------------------
+
+template<typename T, typename...Args>
+inline bit::stl::exclusive_ptr<T> bit::stl::make_exclusive( Args&&...args )
+{
+  return allocate_exclusive<T>( std::allocator<void>{},
+                                std::forward<Args>(args)... );
+}
+
+template<typename T, typename Allocator, typename...Args>
+inline bit::stl::exclusive_ptr<T>
+  bit::stl::allocate_exclusive( const Allocator& alloc,
+                                Args&&...args )
+{
+  using tag_type      = typename exclusive_ptr<T>::ctor_tag;
+  using control_block = detail::exclusive_ptr_emplace<T,Allocator>;
+  using alloc_traits  = typename std::allocator_traits<Allocator>::template rebind_traits<control_block>;
+  using allocator     = typename alloc_traits::allocator_type;
+  using destructor    = allocator_deleter<allocator>;
+
+  allocator alloc2(alloc);
+  destructor d{alloc2,1};
+  std::unique_ptr<control_block,destructor> hold( alloc2.allocate(1), d );
+  alloc_traits::construct( alloc2, hold.get(), alloc, std::forward<Args>(args)... );
+
+  auto* ptr   = hold.get()->get();
+  auto* block = hold.release();
+  return { tag_type{}, block, ptr };
+}
+
+//-----------------------------------------------------------------------------
+// Casts
+//-----------------------------------------------------------------------------
+
+template<typename T, typename U>
+inline bit::stl::exclusive_ptr<T>
+  bit::stl::casts::static_pointer_cast( exclusive_ptr<U>&& other )
+{
+  return detail::static_pointer_cast<T>( std::move(other) );
+}
+
+template<typename T, typename U>
+inline bit::stl::exclusive_ptr<T>
+  bit::stl::casts::dynamic_pointer_cast( exclusive_ptr<U>&& other )
+{
+  return detail::dynamic_pointer_cast<T>( std::move(other) );
+}
+
+template<typename T, typename U>
+inline bit::stl::exclusive_ptr<T>
+  bit::stl::casts::const_pointer_cast( exclusive_ptr<U>&& other )
+{
+  return detail::const_pointer_cast<T>( std::move(other) );
+}
+
+template<typename T, typename U>
+inline bit::stl::exclusive_ptr<T>
+  bit::stl::casts::reinterpret_pointer_cast( exclusive_ptr<U>&& other )
+{
+  return detail::reinterpret_pointer_cast<T>( std::move(other) );
+}
+
+#endif //BIT_STL_MEMORY_DETAIL_EXCLUSIVE_PTR_INL

--- a/include/bit/stl/memory/exclusive_ptr.hpp
+++ b/include/bit/stl/memory/exclusive_ptr.hpp
@@ -1,0 +1,463 @@
+#ifndef BIT_STL_MEMORY_EXCLUSIVE_PTR_HPP
+#define BIT_STL_MEMORY_EXCLUSIVE_PTR_HPP
+
+#include "../utilities/compressed_tuple.hpp"
+#include "allocator_deleter.hpp"
+
+#include <utility>     // std::piecewise_construct, std::move, std::forward
+#include <tuple>       // std::forward_as_tuple
+#include <memory>      // std::default_delete
+#include <type_traits> // std::add_lvalue_reference_t
+
+namespace bit {
+  namespace stl {
+    template<typename> class exclusive_ptr;
+
+    namespace detail {
+      class exclusive_ptr_control_block;
+      template<typename,typename> class exclusive_ptr_emplace;
+      template<typename,typename,typename> class exclusive_ptr_pointer;
+      template<typename T, typename U>
+      exclusive_ptr<T> static_pointer_cast( exclusive_ptr<U>&& other );
+      template<typename T, typename U>
+      exclusive_ptr<T> dynamic_pointer_cast( exclusive_ptr<U>&& other );
+      template<typename T, typename U>
+      exclusive_ptr<T> const_pointer_cast( exclusive_ptr<U>&& other );
+      template<typename T, typename U>
+      exclusive_ptr<T> reinterpret_pointer_cast( exclusive_ptr<U>&& other );
+    } // namespace detail
+
+    //=========================================================================
+    // X.Y.1 : exclusive_ptr
+    //=========================================================================
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// \brief An RAII wrapper around an allocated piece of memory with unique
+    ///        ownership semantics.
+    ///
+    /// Unlike unique_ptr, this type type-erases the allocator and deleter.
+    /// This provides flexibility at the cost of a virtual call for destructor,
+    /// and some possible spacial overhead of 1 extra pointer along with any
+    /// additional storage required by Deleter and Allocator types.
+    ///
+    /// In the  case where Deleter and Allocator are both stateless, and
+    /// this type is allocated by a call to 'make_exclusive' or
+    /// 'allocate_exclusive', then the additional storage is fixed at
+    /// 2 pointers on the stack, and no additional heap memory.
+    ///
+    /// This is useful for classes that require unique ownership semantics,
+    /// but offer flexibility on the underlying allocator type that can be
+    /// used without wanting to expose the entire class as a template.
+    ///
+    /// \tparam T The type pointed to by this exclusive_ptr
+    ///////////////////////////////////////////////////////////////////////////
+    template<typename T>
+    class exclusive_ptr
+    {
+      //-----------------------------------------------------------------------
+      // Public Member Types
+      //-----------------------------------------------------------------------
+    public:
+
+      using element_type = std::remove_extent_t<T>;
+
+      //-----------------------------------------------------------------------
+      // Constructors / Destructor / Assignment
+      //-----------------------------------------------------------------------
+    public:
+
+      /// \{
+      /// \brief Constructs an exclusive_ptr that points to nullptr
+      ///
+      /// \post \c get() returns \c nullptr
+      constexpr exclusive_ptr() noexcept;
+      constexpr exclusive_ptr( std::nullptr_t ) noexcept;
+      /// \}
+
+      /// \brief Constructs an exclusive_ptr that points to \p ptr
+      ///
+      /// \note This function only participates in overload resolution if \c Y*
+      ///       is convertible to T*
+      ///
+      /// Use of this particular constructor is discouraged with exclusive_ptr
+      /// since it allocates additional heap memory. Prefer 'make_exclusive' or
+      /// 'allocate_exclusive' whenever possible
+      ///
+      /// \post \c get() returns \p ptr
+      ///
+      /// \param ptr the pointer to point to
+      template<typename Y,
+               typename=std::enable_if_t<std::is_convertible<Y*,T*>::value>>
+      explicit exclusive_ptr( Y* ptr );
+
+      /// \brief Constructs an exclusive_ptr that points to \p ptr and is
+      ///        deleted by \p deleter
+      ///
+      /// \note This function only participates in overload resolution if \c Y*
+      ///       is convertible to T*
+      ///
+      /// Use of this particular constructor is discouraged with exclusive_ptr
+      /// since it allocates additional heap memory. Prefer 'make_exclusive' or
+      /// 'allocate_exclusive' whenever possible
+      ///
+      /// \post \c get() returns \p ptr
+      ///
+      /// \param ptr the pointer to point to
+      /// \param deleter the deleter to use to deleter \p ptr
+      template<typename Y, typename Deleter,
+               typename=std::enable_if_t<std::is_convertible<Y*,T*>::value>>
+      explicit exclusive_ptr( Y* ptr, Deleter deleter );
+
+      /// \brief Constructs an exclusive_ptr that points to nullptr
+      ///
+      /// \post \c get() returns \c nullptr
+      template<typename Deleter>
+      exclusive_ptr( std::nullptr_t, Deleter ) noexcept;
+
+      /// \brief Constructs an exclusive_ptr that points to \p ptr,
+      ///        uses \p deleter to delete the allocated memory, and
+      ///        uses \p alloc to allocate the node
+      ///
+      /// \note This function only participates in overload resolution if \c Y*
+      ///       is convertible to T*
+      ///
+      /// \post \c get() returns \p ptr
+      ///
+      /// \param ptr the pointer to point to
+      /// \param deleter the deleter to use to deleter \p ptr
+      /// \param alloc the allocator to allocate the node
+      template<typename Y, typename Deleter, typename Allocator,
+               typename=std::enable_if_t<std::is_convertible<Y*,T*>::value>>
+      exclusive_ptr( Y* ptr, Deleter deleter, Allocator alloc );
+
+      /// \brief Constructs an exclusive_ptr that points to nullptr
+      ///
+      /// \post \c get() returns \c nullptr
+      template<typename Deleter, typename Allocator>
+      exclusive_ptr( std::nullptr_t, Deleter, Allocator ) noexcept;
+
+      /// \brief Move-constructs this exclusive_ptr from an existing one
+      ///
+      /// \post \c other.get() returns \c nullptr
+      ///
+      /// \post \c get() returns the old value of \c other.get()
+      ///
+      /// \param other the other exclusive_ptr to move
+      exclusive_ptr( exclusive_ptr&& other ) noexcept;
+
+      /// \brief Move-converts this exclusive_ptr from an existing one
+      ///
+      /// \note This function only participates in overload resolution if \c Y*
+      ///       is convertible to T*
+      ///
+      /// \post \c other.get() returns \c nullptr
+      ///
+      /// \post \c get() returns the old value of \c other.get()
+      ///
+      /// \param other the other exclusive_ptr to c
+      template<typename Y,
+               typename=std::enable_if_t<std::is_convertible<Y*,T*>::value>>
+      exclusive_ptr( exclusive_ptr<Y>&& other ) noexcept;
+
+      //-----------------------------------------------------------------------
+
+      /// \brief Destroys this exclusive_ptr, freeing up any resources
+      ~exclusive_ptr();
+
+      //-----------------------------------------------------------------------
+
+      /// \brief Move-assigns an exclusive_ptr to this \p exclusive_ptr
+      ///
+      /// \post \c other.get() returns \c nullptr
+      ///
+      /// \post \c get() returns the old pointer from \c other.get()
+      ///
+      /// \param other the other exclusive_ptr to move
+      /// \return reference to \c (*this)
+      exclusive_ptr& operator=( exclusive_ptr&& other ) noexcept;
+
+      /// \brief Move-assigns an exclusive_ptr to this \p exclusive_ptr
+      ///
+      /// \note This function only participates in overload resolution if \c Y*
+      ///       is convertible to T*
+      ///
+      /// \post \c other.get() returns \c nullptr
+      ///
+      /// \post \c get() returns the old pointer from \c other.get()
+      ///
+      /// \param other the other exclusive_ptr to move
+      /// \return reference to \c (*this)
+      template<typename Y,
+               typename=std::enable_if_t<std::is_convertible<Y*,T*>::value>>
+      exclusive_ptr& operator=( exclusive_ptr<Y>&& other ) noexcept;
+
+      /// \brief Assigns \c nullptr to this \c exclusive_ptr
+      ///
+      /// \post \c get() returns \c nullptr
+      ///
+      /// \return reference to \c (*this)
+      exclusive_ptr& operator=( std::nullptr_t ) noexcept;
+
+      //-----------------------------------------------------------------------
+      // Modifiers
+      //-----------------------------------------------------------------------
+
+      /// \brief Resets this exclusive_ptr to \c nullptr, freeing any resources
+      ///
+      /// \post \c get() returns \c nullptr
+      void reset() noexcept;
+
+      /// \{
+      /// \brief Resets this exclusive_ptr to the specified \p ptr
+      ///
+      /// \note This function only participates in overload resolution if \c Y*
+      ///       is convertible to T*
+      ///
+      /// \param ptr the pointer to watch
+      /// \param deleter the deleter to free \p ptr with
+      /// \param alloc the allocator to allocate the new node with
+      template<typename Y,
+               typename=std::enable_if_t<std::is_convertible<Y*,T*>::value>>
+      void reset( Y* ptr );
+      template<typename Y, typename Deleter,
+               typename=std::enable_if_t<std::is_convertible<Y*,T*>::value>>
+      void reset( Y* ptr, Deleter deleter );
+      template<typename Y, typename Deleter, typename Allocator,
+               typename=std::enable_if_t<std::is_convertible<Y*,T*>::value>>
+      void reset( Y* ptr, Deleter deleter, Allocator alloc );
+      /// \}
+
+      //-----------------------------------------------------------------------
+
+      /// \brief Swaps the contents of \c this with \p other
+      ///
+      /// \post \p other contains the old contents of \c this, and \c this
+      ///       contains the old contents of \p other
+      ///
+      /// \param other the other pointer to swap with
+      void swap( exclusive_ptr& other ) noexcept;
+
+      //-----------------------------------------------------------------------
+      // Observers
+      //-----------------------------------------------------------------------
+
+      /// \brief Gets a pointer to the underlying element
+      ///
+      /// \return pointer to the element
+      element_type* get() const noexcept;
+
+      /// \brief Indexes into the array pointed to by this exclusive_ptr
+      ///
+      /// \note This function only partiicpates in overload resolution if
+      ///       \c T is an array type
+      ///
+      /// \param i the index entry to point to
+      /// \return reference to \c the indexed entry
+      template<typename U=T,
+               typename=std::enable_if_t<std::is_array<U>::value>>
+      std::add_lvalue_reference_t<element_type>
+        operator[]( std::ptrdiff_t i ) noexcept;
+
+      /// \brief Dereferences the exclusive_ptr
+      ///
+      /// \pre \c get() returns non-null
+      ///
+      /// \return reference to the pointed-to element
+      std::add_lvalue_reference_t<element_type>
+        operator*() const noexcept;
+
+      /// \brief Dereferences the exclusive_ptr
+      ///
+      /// \pre \c get() returns non-null
+      ///
+      /// \return pointer to the element
+      element_type* operator->() const noexcept;
+
+      /// \brief Returns \c true if this pointer is non-null
+      ///
+      /// \return \c true if this pointer is non-null
+      explicit operator bool() const noexcept;
+
+      //-----------------------------------------------------------------------
+      // Private Member Types
+      //-----------------------------------------------------------------------
+    private:
+
+      struct ctor_tag{};
+      using control_block_type = detail::exclusive_ptr_control_block;
+
+      //-----------------------------------------------------------------------
+      // Private Members
+      //-----------------------------------------------------------------------
+    private:
+
+      control_block_type* m_control_block;
+      element_type*       m_ptr;
+
+      template<typename> friend class exclusive_ptr;
+
+      //-----------------------------------------------------------------------
+      // Private Constructors
+      //-----------------------------------------------------------------------
+    private:
+
+      /// \brief Constructs this exclusive_ptr from the given control block and
+      ///        pointer
+      ///
+      /// \param block the control block
+      /// \param ptr the pointer to the managed element
+      exclusive_ptr( ctor_tag,
+                     control_block_type* block,
+                     T* ptr ) noexcept;
+
+      //-----------------------------------------------------------------------
+      // Friendships
+      //-----------------------------------------------------------------------
+    private:
+
+      template<typename Deleter, typename U>
+      friend Deleter* get_deleter( const exclusive_ptr<U>& );
+
+      template<typename U, typename...Args>
+      friend exclusive_ptr<U> make_exclusive( Args&&...args );
+
+      template<typename U, typename Allocator, typename...Args>
+      friend exclusive_ptr<U> allocate_exclusive( const Allocator& allocator, Args&&...args );
+
+      template<typename Y, typename U>
+      friend exclusive_ptr<Y> detail::static_pointer_cast( exclusive_ptr<U>&& other );
+      template<typename Y, typename U>
+      friend exclusive_ptr<Y> detail::dynamic_pointer_cast( exclusive_ptr<U>&& other );
+      template<typename Y, typename U>
+      friend exclusive_ptr<Y> detail::const_pointer_cast( exclusive_ptr<U>&& other );
+      template<typename Y, typename U>
+      friend exclusive_ptr<Y> detail::reinterpret_pointer_cast( exclusive_ptr<U>&& other );
+
+    };
+
+    //-------------------------------------------------------------------------
+    // Comparison
+    //-------------------------------------------------------------------------
+
+    template<typename T>
+    bool operator==( const exclusive_ptr<T>& lhs, const exclusive_ptr<T>& rhs ) noexcept;
+    template<typename T>
+    bool operator!=( const exclusive_ptr<T>& lhs, const exclusive_ptr<T>& rhs ) noexcept;
+    template<typename T>
+    bool operator<( const exclusive_ptr<T>& lhs, const exclusive_ptr<T>& rhs ) noexcept;
+    template<typename T>
+    bool operator>( const exclusive_ptr<T>& lhs, const exclusive_ptr<T>& rhs ) noexcept;
+    template<typename T>
+    bool operator<=( const exclusive_ptr<T>& lhs, const exclusive_ptr<T>& rhs ) noexcept;
+    template<typename T>
+    bool operator>=( const exclusive_ptr<T>& lhs, const exclusive_ptr<T>& rhs ) noexcept;
+
+    template<typename T>
+    bool operator==( const exclusive_ptr<T>& lhs, std::nullptr_t ) noexcept;
+    template<typename T>
+    bool operator==( std::nullptr_t, const exclusive_ptr<T>& rhs ) noexcept;
+    template<typename T>
+    bool operator!=( const exclusive_ptr<T>& lhs, std::nullptr_t ) noexcept;
+    template<typename T>
+    bool operator!=( std::nullptr_t, const exclusive_ptr<T>& rhs ) noexcept;
+    template<typename T>
+    bool operator<( const exclusive_ptr<T>& lhs, std::nullptr_t ) noexcept;
+    template<typename T>
+    bool operator<( std::nullptr_t, const exclusive_ptr<T>& rhs ) noexcept;
+    template<typename T>
+    bool operator>( const exclusive_ptr<T>& lhs, std::nullptr_t ) noexcept;
+    template<typename T>
+    bool operator>( std::nullptr_t, const exclusive_ptr<T>& rhs ) noexcept;
+    template<typename T>
+    bool operator<=( const exclusive_ptr<T>& lhs, std::nullptr_t ) noexcept;
+    template<typename T>
+    bool operator<=( std::nullptr_t, const exclusive_ptr<T>& rhs ) noexcept;
+    template<typename T>
+    bool operator>=( const exclusive_ptr<T>& lhs, std::nullptr_t ) noexcept;
+    template<typename T>
+    bool operator>=( std::nullptr_t, const exclusive_ptr<T>& rhs ) noexcept;
+
+    //-------------------------------------------------------------------------
+    // Utilities
+    //-------------------------------------------------------------------------
+
+    /// \brief Swaps the contents of \p lhs with \p rhs
+    ///
+    /// \post the old contents of \p lhs are in \p rhs and the old contents of
+    ///       \p rhs are in \p lhs
+    ///
+    /// \param lhs the left exclusive_ptr to swap
+    /// \param rhs the right exclusive_ptr to swap
+    template<typename T>
+    void swap( exclusive_ptr<T>& lhs, exclusive_ptr<T>& rhs ) noexcept;
+
+    //-------------------------------------------------------------------------
+
+    /// \brief Gets the deleter from \p ptr
+    ///
+    /// \tparam Deleter the type of the deleter to retrieve
+    /// \param ptr the exclusive_ptr to get the deleter from
+    /// \return the deleter
+    template<typename Deleter, typename T>
+    Deleter* get_deleter( const exclusive_ptr<T>& ptr );
+
+    //-------------------------------------------------------------------------
+
+    /// \brief Makes an exclusive_ptr from the given \p args
+    ///
+    /// \tparam T the type of the exclusive_ptr
+    /// \param args
+    /// \return
+    template<typename T, typename...Args>
+    exclusive_ptr<T> make_exclusive( Args&&...args );
+
+    template<typename T, typename Allocator, typename...Args>
+    exclusive_ptr<T> allocate_exclusive( const Allocator& allocator, Args&&...args );
+
+    //-------------------------------------------------------------------------
+    // Casts
+    //-------------------------------------------------------------------------
+
+    inline namespace casts
+    {
+      /// \brief Statically casts an exclusive_ptr of type \c U to type \c T
+      ///
+      /// \tparam T the type to cast to
+      /// \param other the exclusive_ptr to cast
+      /// \return the statically casted exclusive_ptr
+      template<typename T, typename U>
+      exclusive_ptr<T> static_pointer_cast( exclusive_ptr<U>&& other );
+
+      /// \brief Dynamically casts an exclusive_ptr of type \c U to type \c T
+      ///
+      /// If the expression \c dynamic_cast<T*>(other.get()) returns \c nullptr
+      /// then \p other remains unchanged
+      ///
+      /// \tparam T the type to cast to
+      /// \param other the exclusive_ptr to cast
+      /// \return the dynamically casted exclusive_ptr
+      template<typename T, typename U>
+      exclusive_ptr<T> dynamic_pointer_cast( exclusive_ptr<U>&& other );
+
+      /// \brief Const casts an exclusive_ptr of type \c U to type \c T
+      ///
+      /// \tparam T the type to cast to
+      /// \param other the exclusive_ptr to cast
+      /// \return the const casted exclusive_ptr
+      template<typename T, typename U>
+      exclusive_ptr<T> const_pointer_cast( exclusive_ptr<U>&& other );
+
+      /// \brief Reinterpret casts an exclusive_ptr of type \c U to type \c T
+      ///
+      /// \tparam T the type to cast to
+      /// \param other the exclusive_ptr to cast
+      /// \return the reinterpret casted exclusive_ptr
+      template<typename T, typename U>
+      exclusive_ptr<T> reinterpret_pointer_cast( exclusive_ptr<U>&& other );
+    }
+  } // namespace stl
+} // namespace bit
+
+#include "detail/exclusive_ptr.inl"
+
+#endif // BIT_STL_MEMORY_EXCLUSIVE_PTR_HPP

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,9 @@ set(sources
       bit/stl/containers/circular_deque.test.cpp
       bit/stl/containers/circular_buffer.test.cpp
 
+      # memory
+      bit/stl/memory/exclusive_ptr.test.cpp
+
       main.test.cpp
 )
 

--- a/test/bit/stl/memory/exclusive_ptr.test.cpp
+++ b/test/bit/stl/memory/exclusive_ptr.test.cpp
@@ -1,0 +1,175 @@
+
+#include <bit/stl/memory/exclusive_ptr.hpp>
+
+#include <catch.hpp>
+
+namespace
+{
+  class base
+  {
+  public:
+    virtual ~base() = default;
+  };
+
+  class derived : public base{};
+}
+
+//=============================================================================
+// exclusive_ptr
+//=============================================================================
+
+//-----------------------------------------------------------------------------
+// Constructors
+//-----------------------------------------------------------------------------
+
+TEST_CASE("exclusive_ptr<T>::exclusive_ptr()")
+{
+  auto ptr = bit::stl::exclusive_ptr<::base>{};
+
+  SECTION("points to null")
+  {
+    REQUIRE( ptr == nullptr );
+  }
+}
+
+TEST_CASE("exclusive_ptr<T>::exclusive_ptr( std::nullptr_t )")
+{
+  bit::stl::exclusive_ptr<::base> ptr = nullptr;
+
+  SECTION("points to null")
+  {
+    REQUIRE( ptr == nullptr );
+  }
+}
+
+TEST_CASE("exclusive_ptr<T>::exclusive_ptr( exclusive_ptr&& )")
+{
+  auto p1 = bit::stl::make_exclusive<::derived>();
+  auto p1_old = p1.get();
+  auto p2 = std::move(p1);
+
+  SECTION("owns p1's old memory")
+  {
+    REQUIRE( p2.get() == p1_old );
+  }
+  SECTION("p1 is null after move")
+  {
+    REQUIRE( p1 == nullptr );
+  }
+}
+
+TEST_CASE("exclusive_ptr<T>::exclusive_ptr( exclusive_ptr<U>&& )")
+{
+  auto p1 = bit::stl::make_exclusive<::derived>();
+  auto p1_old = p1.get();
+  auto p2 = bit::stl::exclusive_ptr<::base>(std::move(p1));
+
+  SECTION("owns p1's old memory")
+  {
+    REQUIRE( p2.get() == p1_old );
+  }
+  SECTION("p1 is null after move")
+  {
+    REQUIRE( p1 == nullptr );
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+TEST_CASE("exclusive_ptr<T>::operator=( exclusive_ptr&& )")
+{
+  auto p = bit::stl::make_exclusive<::derived>();
+  auto p_old = p.get();
+
+  p = bit::stl::make_exclusive<::derived>();
+
+  SECTION("no longer refers to p1's old memory")
+  {
+    REQUIRE( p.get() != p_old );
+  }
+}
+
+TEST_CASE("exclusive_ptr<T>::operator=( exclusive_ptr<U>&& )")
+{
+  auto p = bit::stl::make_exclusive<::base>();
+  auto p_old = p.get();
+
+  p = bit::stl::make_exclusive<::derived>();
+
+  SECTION("no longer refers to p1's old memory")
+  {
+    REQUIRE( p.get() != p_old );
+  }
+}
+
+//=============================================================================
+// casts
+//=============================================================================
+
+TEST_CASE("casts::dynamic_pointer_cast<T>( exclusive_ptr<U>&& )")
+{
+  using namespace bit::stl::casts;
+
+  auto p1 = bit::stl::make_exclusive<::derived>();
+  auto p1_old = p1.get();
+  auto p2 = bit::stl::exclusive_ptr<::base>(std::move(p1));
+
+  SECTION("Casted type is unrelated")
+  {
+    struct unrelated{};
+
+    auto p3 = dynamic_pointer_cast<unrelated>(std::move(p2));
+
+    SECTION("Result is null")
+    {
+      REQUIRE( p3 == nullptr );
+    }
+
+    SECTION("p2 remains unchanged")
+    {
+      REQUIRE( p2.get() == p1_old );
+    }
+  }
+
+  SECTION("Casted type is related")
+  {
+    auto p3 = dynamic_pointer_cast<::base>(std::move(p2));
+
+    SECTION("Result points to original instance")
+    {
+      REQUIRE( p3.get() == p1_old );
+    }
+  }
+}
+
+TEST_CASE("casts::const_pointer_cast<T>( exclusive_ptr<U>&& )")
+{
+  using namespace bit::stl::casts;
+
+  auto p1 = bit::stl::make_exclusive<::derived>();
+  auto p1_old = p1.get();
+  auto p2 = bit::stl::exclusive_ptr<const ::derived>(std::move(p1));
+  auto p3 = const_pointer_cast<::derived>(std::move(p2));
+
+  SECTION("Is const casted back to original pointer")
+  {
+    REQUIRE( p3.get() == p1_old );
+  }
+}
+
+TEST_CASE("casts::reinterpret_pointer_cast<T>( exclusive_ptr<U>&& )")
+{
+  using namespace bit::stl::casts;
+
+  auto p1 = bit::stl::make_exclusive<::derived>();
+  auto p1_old = p1.get();
+  auto p2 = bit::stl::exclusive_ptr<void>(std::move(p1));
+  auto p3 = reinterpret_pointer_cast<::derived>(std::move(p2));
+
+  SECTION("Is reinterpret casted back to original pointer")
+  {
+    REQUIRE( p3.get() == p1_old );
+  }
+}
+
+//-----------------------------------------------------------------------------


### PR DESCRIPTION
This adds a new smart pointer type called 'exclusive_ptr'

'exclusive_ptr' is a uniquely owned RAII smart pointer type akin to
unique_ptr -- only it uses a pair of pointers with a control block
much like 'shared_ptr'. This type-erases the allocator and deleter
to allow for a much simpler manner of returning allocated pointers
without requiring a template argument for the deleter everywhere.
Additionally, this type-erasure facilitates easy conversions from
derived to base types and back, even when using custom allocators
(something not as easily done with the standrd unique_ptr).

In the common case of std::allocator and std::default_delete, there
is no additional heap-allocated spacial overhead when using
bit::stl::make_exclusive, since the control block is EBO-aware. There
is the additional overhead of one more stack pointer member than the
standard unique_ptr, since 'exclusive_ptr' requires a pointer to the
control block. This effectively makes the sizeof(exclusive_ptr)
equal to 2*sizeof(unique_ptr).

There *may* be a small performance impact on invocation of destructors
since this requires a virtual call, however in practice this should
be negligable, especially when used with higher compiler optimization
levels. An exclusive_ptr that can statically determine the underlying
type should be subject to inline optimizations.