### PR TITLE
Cleanup miscellaneous implementation details

### DIFF
--- a/include/bit/stl/containers/array.hpp
+++ b/include/bit/stl/containers/array.hpp
@@ -65,7 +65,7 @@ namespace bit {
     /// \brief Make utility for creating a std::array
     ///
     /// If the return type is explicitly specified, no deduction take place;
-    /// if the type is ommitted, the return type is the common type of all
+    /// if the type is omitted, the return type is the common type of all
     /// inputs.
     ///
     /// \tparam T the return type of the array.

--- a/include/bit/stl/memory/detail/allocator_deleter.inl
+++ b/include/bit/stl/memory/detail/allocator_deleter.inl
@@ -27,6 +27,7 @@ template<typename Allocator>
 void bit::stl::allocator_deleter<Allocator>::operator()( pointer p )
   noexcept
 {
+  alloc_traits::destroy( m_allocator, p );
   alloc_traits::deallocate( m_allocator, p, m_size );
 }
 

--- a/include/bit/stl/memory/detail/exclusive_ptr.inl
+++ b/include/bit/stl/memory/detail/exclusive_ptr.inl
@@ -285,9 +285,8 @@ inline bit::stl::exclusive_ptr<T>::exclusive_ptr( Y* ptr, Deleter deleter )
 template<typename T>
 template<typename Deleter>
 inline bit::stl::exclusive_ptr<T>::exclusive_ptr( std::nullptr_t,
-                                                  Deleter )
-  noexcept
-  : exclusive_ptr( nullptr )
+                                                  Deleter deleter )
+  : exclusive_ptr( static_cast<T*>(nullptr), deleter )
 {
 
 }
@@ -304,10 +303,9 @@ inline bit::stl::exclusive_ptr<T>::exclusive_ptr( Y* ptr,
 template<typename T>
 template<typename Deleter, typename Allocator>
 inline bit::stl::exclusive_ptr<T>::exclusive_ptr( std::nullptr_t,
-                                                  Deleter,
-                                                  Allocator )
-  noexcept
-  : exclusive_ptr( nullptr )
+                                                  Deleter deleter,
+                                                  Allocator alloc )
+  : exclusive_ptr( static_cast<T*>(nullptr), deleter, alloc )
 {
 
 }
@@ -393,7 +391,7 @@ inline void bit::stl::exclusive_ptr<T>::reset()
   if( m_control_block ) {
     m_control_block->destroy();
     m_control_block = nullptr;
-    m_ptr      = nullptr;
+    m_ptr           = nullptr;
   }
 }
 

--- a/include/bit/stl/memory/exclusive_ptr.hpp
+++ b/include/bit/stl/memory/exclusive_ptr.hpp
@@ -145,8 +145,10 @@ namespace bit {
       /// \brief Constructs an exclusive_ptr that points to nullptr
       ///
       /// \post \c get() returns \c nullptr
+      ///
+      /// \param deleter the deleter to use to deleter \p ptr
       template<typename Deleter>
-      exclusive_ptr( std::nullptr_t, Deleter ) noexcept;
+      exclusive_ptr( std::nullptr_t, Deleter deleter );
 
       /// \brief Constructs an exclusive_ptr that points to \p ptr,
       ///        uses \p deleter to delete the allocated memory, and
@@ -167,8 +169,11 @@ namespace bit {
       /// \brief Constructs an exclusive_ptr that points to nullptr
       ///
       /// \post \c get() returns \c nullptr
+      ///
+      /// \param deleter the deleter to use to deleter \p ptr
+      /// \param alloc the allocator to allocate the node
       template<typename Deleter, typename Allocator>
-      exclusive_ptr( std::nullptr_t, Deleter, Allocator ) noexcept;
+      exclusive_ptr( std::nullptr_t, Deleter deleter, Allocator alloc );
 
       /// \brief Move-constructs this exclusive_ptr from an existing one
       ///
@@ -178,6 +183,9 @@ namespace bit {
       ///
       /// \param other the other exclusive_ptr to move
       exclusive_ptr( exclusive_ptr&& other ) noexcept;
+
+      // Deleted copy constructor
+      exclusive_ptr( const exclusive_ptr& other ) = delete;
 
       /// \brief Move-converts this exclusive_ptr from an existing one
       ///
@@ -192,6 +200,11 @@ namespace bit {
       template<typename Y,
                typename=std::enable_if_t<std::is_convertible<Y*,T*>::value>>
       exclusive_ptr( exclusive_ptr<Y>&& other ) noexcept;
+
+      // Deleted copy converting constructor
+      template<typename Y,
+               typename=std::enable_if_t<std::is_convertible<Y*,T*>::value>>
+      exclusive_ptr( const exclusive_ptr<Y>& other ) = delete;
 
       //-----------------------------------------------------------------------
 

--- a/include/bit/stl/traits/composition/bool_constant.hpp
+++ b/include/bit/stl/traits/composition/bool_constant.hpp
@@ -46,7 +46,7 @@ namespace bit {
     ///
     /// The value is aliased as \c ::value
     template<bool B>
-    using bool_constant = integral_constant<bool,B>;
+    struct bool_constant : integral_constant<bool,B>{};
 
     /// \brief Convenience template variable to extract bool_constant::value
     ///

--- a/include/bit/stl/traits/composition/size_constant.hpp
+++ b/include/bit/stl/traits/composition/size_constant.hpp
@@ -49,7 +49,7 @@ namespace bit {
     ///
     /// The value is aliased as \c ::value
     template<std::size_t Size>
-    using size_constant = std::integral_constant<std::size_t,Size>;
+    struct size_constant : std::integral_constant<std::size_t,Size>{};
 
     /// \brief Convenience template variable to extract size_constant::value
     ///

--- a/include/bit/stl/traits/relationships/nth_type.hpp
+++ b/include/bit/stl/traits/relationships/nth_type.hpp
@@ -52,6 +52,9 @@ namespace bit {
     template<std::size_t I, typename Type0, typename...Types>
     struct nth_type<I,Type0, Types...> : nth_type<I-1,Types...>{};
 
+    template<>
+    struct nth_type<0>{}; // SFINAE-disable type
+
     template<typename Type0, typename...Types>
     struct nth_type<0,Type0,Types...> : identity<Type0>{};
 

--- a/include/bit/stl/utilities/types.hpp
+++ b/include/bit/stl/utilities/types.hpp
@@ -171,7 +171,7 @@ namespace bit {
     /// \note member_t is unable to deduce it's template parameters if
     ///       used in a deduction context.
     template<typename T, typename R>
-    using member_t = R T::*;
+    using member_pointer = R T::*;
 
     /// \brief A type alias for member function pointers to make it more
     ///        readable.
@@ -179,14 +179,14 @@ namespace bit {
     /// \note member_function_t is unable to deduce it's template parameters
     ///       if used in a deduction context.
     template<typename T, typename Fn>
-    using member_function_t = typename detail::member_function_t<T,Fn>::type;
+    using member_function_pointer = typename detail::member_function_t<T,Fn>::type;
 
     /// \brief A type alias for function pointers to make it more readable
     ///
     /// \note That function_t is unable to deduce it's template parameters
     ///       if used in a deduction context.
     template<typename Fn>
-    using function_t = typename detail::function_t<Fn>::type;
+    using function_pointer = typename detail::function_t<Fn>::type;
 
   } // namespace stl
 } // namespace bit

--- a/test/bit/stl/utilities/delegate.test.cpp
+++ b/test/bit/stl/utilities/delegate.test.cpp
@@ -16,23 +16,24 @@ namespace {
   // Dummy Classes
   //----------------------------------------------------------------------------
 
-  int dummy_function(int a)
+  int plus_one(int a)
   {
     return a + 1;
   }
 
   //----------------------------------------------------------------------------
 
-  class DummyClass
+  class plus_n
   {
   public:
-    DummyClass( int value ) : m_value(value){}
+    plus_n( int value ) : m_value(value){}
 
     int non_const_function( int a ) { return m_value + a; }
     int const_function( int a ) const { return m_value + a; }
 
     int m_value;
   };
+
 
 } // anonymous namespace
 
@@ -61,7 +62,7 @@ TEST_CASE("delegate::bind()", "[member function]")
   {
     bit::stl::delegate<int(int)> delegate;
 
-    delegate.bind<dummy_function>();
+    delegate.bind<&::plus_one>();
     REQUIRE( delegate.is_bound() );
   }
 }
@@ -70,19 +71,19 @@ TEST_CASE("delegate::bind( T& )", "[member function]")
 {
   SECTION("Binds non-const member function")
   {
-    bit::stl::delegate<int(int)> delegate;
-    DummyClass              dummy(10);
+    auto delegate = bit::stl::delegate<int(int)>{};
+    auto dummy    = ::plus_n{10};
 
-    delegate.bind<DummyClass,&DummyClass::non_const_function>(dummy);
+    delegate.bind<plus_n,&plus_n::non_const_function>(dummy);
     REQUIRE( delegate.is_bound() );
   }
 
   SECTION("Binds const member function")
   {
-    bit::stl::delegate<int(int)> delegate;
-    const DummyClass        dummy(10);
+    auto delegate = bit::stl::delegate<int(int)>{};
+    const auto dummy = ::plus_n{10};
 
-    delegate.bind<DummyClass,&DummyClass::const_function>(dummy);
+    delegate.bind<plus_n,&plus_n::const_function>(dummy);
     REQUIRE( delegate.is_bound() );
   }
 }
@@ -93,16 +94,16 @@ TEST_CASE("delegate::is_bound()", "[member function]")
 {
   SECTION("Returns false when not bound")
   {
-    bit::stl::delegate<int(int)> delegate;
+    auto delegate = bit::stl::delegate<int(int)>{};
 
     REQUIRE_FALSE( delegate.is_bound() );
   }
 
   SECTION("Returns true when bound")
   {
-    bit::stl::delegate<int(int)> delegate;
+    auto delegate = bit::stl::delegate<int(int)>{};
 
-    delegate.bind<dummy_function>();
+    delegate.bind<&::plus_one>();
 
     REQUIRE( delegate.is_bound() );
   }
@@ -112,16 +113,16 @@ TEST_CASE("delegate::operator bool", "[member function]")
 {
   SECTION("Is explicitly convertible to false when not bound")
   {
-    bit::stl::delegate<int(int)> delegate;
+    auto delegate = bit::stl::delegate<int(int)>{};
 
     REQUIRE_FALSE( static_cast<bool>(delegate) );
   }
 
   SECTION("Is explicitly convertible to true when bound")
   {
-    bit::stl::delegate<int(int)> delegate;
+    auto delegate = bit::stl::delegate<int(int)>{};
 
-    delegate.bind<dummy_function>();
+    delegate.bind<&::plus_one>();
 
     REQUIRE( static_cast<bool>(delegate) );
   }
@@ -129,35 +130,35 @@ TEST_CASE("delegate::operator bool", "[member function]")
 
 //----------------------------------------------------------------------------
 
-TEST_CASE("delegate::invoke(Args&&...)", "[member function]")
+TEST_CASE("delegate::operator()(Args&&...)", "[member function]")
 {
   SECTION("Invokes bound free function")
   {
-    bit::stl::delegate<int(int)> delegate;
+    auto delegate = bit::stl::delegate<int(int)>{};
 
-    delegate.bind<dummy_function>();
+    delegate.bind<&::plus_one>();
 
-    REQUIRE( delegate.invoke(5) == 6 );
+    REQUIRE( delegate(5) == 6 );
   }
 
   SECTION("Invokes non-const member function")
   {
-    bit::stl::delegate<int(int)> delegate;
-    DummyClass              dummy(10);
+    auto delegate = bit::stl::delegate<int(int)>{};
+    auto dummy    = ::plus_n{10};
 
-    delegate.bind<DummyClass,&DummyClass::non_const_function>(dummy);
+    delegate.bind<plus_n,&plus_n::non_const_function>(dummy);
 
-    REQUIRE( delegate.invoke(5) == 15 );
+    REQUIRE( delegate(5) == 15 );
   }
 
   SECTION("Invokes const member function")
   {
-    bit::stl::delegate<int(int)> delegate;
-    const DummyClass        dummy(10);
+    auto delegate    = bit::stl::delegate<int(int)>{};
+    const auto dummy = ::plus_n{10};
 
-    delegate.bind<DummyClass,&DummyClass::const_function>(dummy);
+    delegate.bind<plus_n,&plus_n::const_function>(dummy);
 
-    REQUIRE( delegate.invoke(5) == 15 );
+    REQUIRE( delegate(5) == 15 );
   }
 }
 


### PR DESCRIPTION
* Cleanup 'delegate' implementation
The 'delegate' class now makes use of the 'function_pointer', and
'member_function_pointer' utilities.

* Fix 'exclusive_ptr' constructors 
The constructors accepting 'nullptr_t' and a deleter or allocator
should create an empty control block which is null, but not valueless
in order to be consistent with std::shared_ptr.

* SFINAE-disable `nth_type` when `n > sizeof...(Types)`
This now provides a template specialization where n is larger than
sizeof...(Types), which results in ::type not being defined. This
allows SFINAE-disabling functionality when out-of-range, leading to
easier detection

* Use inheritance for [bool_/size_]constant 
Both bool_constant and size_constant have now been updated to use
inheritance, rather than template aliasing to define the respective
types. Behaviourally this will be _mostly_ identical to aliases, with
the exception that `std::is_same<T,U>` will be different for queries
of `std::integral_constant` and `bool_constant`.

* Fix documentation typo in array.hpp

* Fix 'allocator_deleter' not destructing object 
allocator_deleter's `operator()` function was missing a call to
'destroy' before deleting the associated object, which could lead to
memory leakage