### PR TITLE
Cleanup travis.yml and gold linker integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ matrix:
         - TEST="g++-7 Undefined Behavior Sanitizer"
         - COMPILER=g++-7
         - CONFIGURATION=Debug
-        - CMAKE_ARGS="-DBIT_STL_COMPILE_USAN=On"
+        - CMAKE_ARGS="-DBIT_STL_COMPILE_UBSAN=On"
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
@@ -163,7 +163,7 @@ matrix:
         - TEST="clang++-5.0 Undefined Behavior Sanitizer"
         - COMPILER=clang++-5.0
         - CONFIGURATION=Debug
-        - CMAKE_ARGS="-DBIT_STL_COMPILE_USAN=On"
+        - CMAKE_ARGS="-DBIT_STL_COMPILE_UBSAN=On"
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-5.0']
@@ -250,6 +250,7 @@ matrix:
 # Installation Steps #
 ######################
 install:
+  - old_dir=$(pwd)
   - cd ../
 
   # Get dependency 'catch'
@@ -267,7 +268,7 @@ install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then tar -xzf cmake-3.9.4-Darwin-x86_64.tar.gz && ls && ls cmake-3.9.4-Darwin-x86_64; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CMAKE=$TRAVIS_BUILD_DIR/../cmake-3.9.4-Darwin-x86_64/CMake.app/Contents/bin/cmake; fi
 
-  - cd bit-stl/
+  - cd $old_dir
 
 ##################
 # Pre-build step #
@@ -289,6 +290,11 @@ before_script:
   - CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_INCLUDE_PATH=$CATCH_DIR"
   - CMAKE_ARGS="$CMAKE_ARGS -DBIT_STL_COMPILE_UNIT_TESTS=On"
   - CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_CXX_COMPILER=$COMPILER"
+
+  # Use ld.gold on non-OSX builds
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_SHARED_LINKER_FLAGS=\"-fuse-ld=gold\""; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_EXE_LINKER_FLAGS=\"-fuse-ld=gold\"""; fi
+
 
 ######################
 # Default Build Step #

--- a/.travis.yml
+++ b/.travis.yml
@@ -293,7 +293,7 @@ before_script:
 
   # Use ld.gold on non-OSX builds
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_SHARED_LINKER_FLAGS=\"-fuse-ld=gold\""; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_EXE_LINKER_FLAGS=\"-fuse-ld=gold\"""; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_EXE_LINKER_FLAGS=\"-fuse-ld=gold\""; fi
 
 
 ######################

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.1)
 #-----------------------------------------------------------------------------
 
 option(BIT_STL_COMPILE_ASAN "Compile and run the address sanetizer" off)
-option(BIT_STL_COMPILE_USAN "Compile and run the undefined behavior sanitizer" off)
+option(BIT_STL_COMPILE_UBSAN "Compile and run the undefined behavior sanitizer" off)
 option(BIT_STL_COMPILE_TSAN "Compile and run the thread sanitizer" off)
 option(BIT_STL_COMPILE_COVERAGE "Compile and run code coverage" off)
 
@@ -54,28 +54,29 @@ add_test( NAME "bit_stl_test_all"
           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
           COMMAND "$<TARGET_FILE:bit_stl_test>" "*" )
 
+if( BIT_STL_COMPILE_TSAN AND BIT_STL_COMPILE_UBSAN OR
+    BIT_STL_COMPILE_UBSAN AND BIT_STL_COMPILE_ASAN OR
+    BIT_STL_COMPILE_ASAN AND BIT_STL_COMPILE_TSAN )
+  message(FATAL_ERROR "TSAN, UBSAN, and ASAN can only be enabled independently")
+endif()
+
 #-----------------------------------------------------------------------------
 # Address Sanitizer
 #-----------------------------------------------------------------------------
 
 if( BIT_STL_COMPILE_ASAN )
 
-  if( NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" )
-    message(FATAL_ERROR "ASAN only available for LLVM Clang compilers")
+  if( NOT UNIX )
+    message(FATAL_ERROR "UBSAN only available posix platforms")
   endif()
 
   target_link_libraries(bit_stl_test PRIVATE -fsanitize=address
-                                             -fsanitize=leak
-                                             -fuse-ld=gold)
-
-  target_compile_options(bit_stl_test PRIVATE
-    -g
-    -O1
-    -fno-omit-frame-pointer
-    -fsanitize=address
-    -fsanitize=leak
-    -fuse-ld=gold
-  )
+                                             -fsanitize=leak)
+  target_compile_options(bit_stl_test PRIVATE -fsanitize=address
+                                              -fsanitize=leak
+                                              -g
+                                              -O1
+                                              -fno-omit-frame-pointer)
 
 endif()
 
@@ -83,14 +84,14 @@ endif()
 # Undefined Behavior Sanitizer
 #-----------------------------------------------------------------------------
 
-if( BIT_STL_COMPILE_USAN )
+if( BIT_STL_COMPILE_UBSAN )
 
-  if( NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" )
-    message(FATAL_ERROR "USAN only available for LLVM Clang compilers")
+  if( NOT UNIX )
+    message(FATAL_ERROR "UBSAN only available posix platforms")
   endif()
 
-  target_compile_options(bit_stl_test PRIVATE -fsanitize=undefined -fuse-ld=gold)
-  target_link_libraries(bit_stl_test PRIVATE -fsanitize=undefined -fuse-ld=gold)
+  target_compile_options(bit_stl_test PRIVATE -fsanitize=undefined)
+  target_link_libraries(bit_stl_test PRIVATE -fsanitize=undefined)
 
 endif()
 
@@ -100,12 +101,12 @@ endif()
 
 if( BIT_STL_COMPILE_TSAN )
 
-  if( NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" )
-    message(FATAL_ERROR "TSAN only available for LLVM Clang compilers")
+  if( NOT UNIX )
+    message(FATAL_ERROR "UBSAN only available posix platforms")
   endif()
 
-  target_compile_options(bit_stl_test PRIVATE -fsanitize=thread -fuse-ld=gold)
-  target_link_libraries(bit_stl_test PRIVATE -fsanitize=thread -fuse-ld=gold)
+  target_compile_options(bit_stl_test PRIVATE -fsanitize=thread)
+  target_link_libraries(bit_stl_test PRIVATE -fsanitize=thread)
 
 endif()
 
@@ -115,8 +116,9 @@ endif()
 
 if( BIT_STL_COMPILE_COVERAGE )
 
-  if( NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" )
-    message(FATAL_ERROR "Coverage only available for LLVM Clang compilers")
+  if( NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND
+      NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" )
+    message(FATAL_ERROR "Coverage only available for GNUC compilers")
   endif()
 
   target_link_libraries(bit_stl_test PRIVATE --coverage)


### PR DESCRIPTION
The gold linker flag has been removed from the `CMakeLists.txt` settings, 
and instead added as a command line parameter to the `travis.yml` files.