### PR TITLE
Add adl::get for tuple utilities

### DIFF
--- a/include/bit/stl/functional/extraction/use_first.hpp
+++ b/include/bit/stl/functional/extraction/use_first.hpp
@@ -39,6 +39,8 @@
 #include "../../traits/composition/bool_constant.hpp"
 #include "../../traits/composition/void_t.hpp"
 
+#include "../../utilities/tuple_utilities.hpp" // adl::get
+
 #include <type_traits> // std::declval, std::enable_if_t
 #include <utility>     // std::forward
 
@@ -47,18 +49,19 @@ namespace bit {
 
     struct use_first
     {
-      template<typename Pair>
-      constexpr decltype(auto) operator()( Pair&& pair );
+      template<typename Tuple>
+      constexpr decltype(auto) operator()( Tuple&& tuple );
     };
 
   } // namespace stl
 } // namespace bit
 
-template<typename Pair>
-inline constexpr decltype(auto) bit::stl::use_first::operator()( Pair&& pair )
+template<typename Tuple>
+inline constexpr decltype(auto) bit::stl::use_first::operator()( Tuple&& tuple )
 {
-  using std::get;
-  return get<0>(pair);
+  using ::bit::stl::adl::get;
+
+  return get<0>( std::forward<Tuple>(tuple) );
 }
 
 #endif /* BIT_STL_FUNCTIONAL_EXTRACTION_USE_FIRST_HPP */

--- a/include/bit/stl/functional/extraction/use_nth_element.hpp
+++ b/include/bit/stl/functional/extraction/use_nth_element.hpp
@@ -36,8 +36,10 @@
 # pragma once
 #endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
 
+#include "../../utilities/tuple_utilities.hpp" // adl::get
+
 #include <cstddef> // std::size_t
-#include <utility> // std::forward, std::get
+#include <utility> // std::forward
 
 namespace bit {
   namespace stl {
@@ -58,7 +60,7 @@ inline constexpr decltype(auto) bit::stl::use_nth_element<N>
   ::operator()( Tuple&& tuple )
 {
   // ADL-lookup 'get<N>'
-  using std::get;
+  using ::bit::stl::adl::get;
 
   return get<N>( std::forward<Tuple>(tuple) );
 }

--- a/include/bit/stl/functional/extraction/use_second.hpp
+++ b/include/bit/stl/functional/extraction/use_second.hpp
@@ -36,6 +36,8 @@
 # pragma once
 #endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
 
+#include "../../utilities/tuple_utilities.hpp" // adl::get
+
 #include <type_traits> // std::declval, std::enable_if_t
 #include <utility>     // std::forward, get
 
@@ -44,19 +46,19 @@ namespace bit {
 
     struct use_second
     {
-      template<typename Pair>
-      constexpr decltype(auto) operator()( Pair&& pair );
+      template<typename Tuple>
+      constexpr decltype(auto) operator()( Tuple&& tuple );
     };
 
   } // namespace stl
 } // namespace bit
 
-template<typename Pair>
-inline constexpr decltype(auto) bit::stl::use_second::operator()( Pair&& pair )
+template<typename Tuple>
+inline constexpr decltype(auto) bit::stl::use_second::operator()( Tuple&& tuple )
 {
-  using std::get;
+  using ::bit::stl::adl::get;
 
-  return get<1>(pair);
+  return get<1>(tuple);
 }
 
 #endif /* BIT_STL_FUNCTIONAL_EXTRACTION_USE_SECOND_HPP */

--- a/include/bit/stl/memory/detail/observer_ptr.inl
+++ b/include/bit/stl/memory/detail/observer_ptr.inl
@@ -445,8 +445,9 @@ inline constexpr bit::stl::observer_ptr<T>
 
 
 template<typename Pointer>
-inline constexpr auto bit::stl::make_observer( const Pointer& ptr )
-  noexcept -> decltype( ::bit::stl::make_observer( ptr.get() ) )
+constexpr bit::stl::observer_ptr<std::remove_pointer_t<decltype(std::declval<const Pointer&>().get())>>
+  bit::stl::make_observer( const Pointer& ptr)
+  noexcept
 {
   return make_observer( ptr.get() );
 }

--- a/include/bit/stl/memory/detail/observer_ptr.inl
+++ b/include/bit/stl/memory/detail/observer_ptr.inl
@@ -446,7 +446,7 @@ inline constexpr bit::stl::observer_ptr<T>
 
 template<typename Pointer>
 inline constexpr auto bit::stl::make_observer( const Pointer& ptr )
-  noexcept -> decltype( make_observer( ptr.get() ) )
+  noexcept -> decltype( ::bit::stl::make_observer( ptr.get() ) )
 {
   return make_observer( ptr.get() );
 }

--- a/include/bit/stl/memory/observer_ptr.hpp
+++ b/include/bit/stl/memory/observer_ptr.hpp
@@ -375,7 +375,7 @@ namespace bit {
     /// \return an observer_ptr
     template<typename Pointer>
     constexpr auto make_observer( const Pointer& ptr ) noexcept
-      -> decltype( make_observer( ptr.get() ) );
+      -> decltype( ::bit::stl::make_observer( ptr.get() ) );
 
     /// \brief Makes an observer_ptr from a smart pointer
     ///

--- a/include/bit/stl/memory/observer_ptr.hpp
+++ b/include/bit/stl/memory/observer_ptr.hpp
@@ -374,9 +374,9 @@ namespace bit {
     /// \param ptr the pointer
     /// \return an observer_ptr
     template<typename Pointer>
-    constexpr auto make_observer( const Pointer& ptr ) noexcept
-      -> decltype( ::bit::stl::make_observer( ptr.get() ) );
-
+    constexpr observer_ptr<std::remove_pointer_t<decltype(std::declval<const Pointer&>().get())>> 
+      make_observer( const Pointer& ptr ) noexcept;
+      
     /// \brief Makes an observer_ptr from a smart pointer
     ///
     /// \tparam T explicit type of the pointer

--- a/include/bit/stl/ranges/detail/move_range.inl
+++ b/include/bit/stl/ranges/detail/move_range.inl
@@ -12,7 +12,7 @@ inline constexpr bit::stl::move_range<Iterator,Sentinel>
 template<typename Range>
 inline constexpr auto
   bit::stl::make_move_range( Range&& r )
-  -> decltype(make_move_range( r.begin(), r.end() ))
+  -> decltype(::bit::stl::make_move_range( r.begin(), r.end() ))
 {
   return make_move_range( std::forward<Range>(r).begin(),
                           std::forward<Range>(r).end() );

--- a/include/bit/stl/ranges/detail/move_range.inl
+++ b/include/bit/stl/ranges/detail/move_range.inl
@@ -12,7 +12,9 @@ inline constexpr bit::stl::move_range<Iterator,Sentinel>
 template<typename Range>
 inline constexpr auto
   bit::stl::make_move_range( Range&& r )
+#ifndef _MSC_VER
   -> decltype(::bit::stl::make_move_range( r.begin(), r.end() ))
+#endif // _MSC_VER
 {
   return make_move_range( std::forward<Range>(r).begin(),
                           std::forward<Range>(r).end() );

--- a/include/bit/stl/ranges/detail/tuple_element_range.inl
+++ b/include/bit/stl/ranges/detail/tuple_element_range.inl
@@ -11,7 +11,9 @@ inline constexpr bit::stl::tuple_element_range<N,Iterator,Sentinel>
 
 template<std::size_t N, typename Range>
 inline constexpr auto bit::stl::make_tuple_element_range( Range&& r )
+#ifndef _MSC_VER
   -> decltype(::bit::stl::make_tuple_element_range<N>( r.begin(), r.end()))
+#endif // _MSC_VER
 {
   return make_tuple_element_range<N>( std::forward<Range>(r).begin(),
                                       std::forward<Range>(r).end() );
@@ -28,7 +30,9 @@ inline constexpr bit::stl::tuple_element_range<0,Iterator,Sentinel>
 
 template<typename Range>
 inline constexpr auto bit::stl::make_key_range( Range&& r )
+#ifndef _MSC_VER
   -> decltype(::bit::stl::make_key_range( r.begin(), r.end()))
+#endif // _MSC_VER
 {
   return make_key_range<0>( std::forward<Range>(r).begin(),
                             std::forward<Range>(r).end() );
@@ -45,7 +49,9 @@ inline constexpr bit::stl::tuple_element_range<1,Iterator,Sentinel>
 
 template<typename Range>
 inline constexpr auto bit::stl::make_value_range( Range&& r )
+#ifndef _MSC_VER
   -> decltype(::bit::stl::make_value_range( r.begin(), r.end()))
+#endif // _MSC_VER
 {
   return make_value_range<1>( std::forward<Range>(r).begin(),
                               std::forward<Range>(r).end() );

--- a/include/bit/stl/ranges/detail/tuple_element_range.inl
+++ b/include/bit/stl/ranges/detail/tuple_element_range.inl
@@ -11,7 +11,7 @@ inline constexpr bit::stl::tuple_element_range<N,Iterator,Sentinel>
 
 template<std::size_t N, typename Range>
 inline constexpr auto bit::stl::make_tuple_element_range( Range&& r )
-  -> decltype(make_tuple_element_range<N>( r.begin(), r.end()))
+  -> decltype(::bit::stl::make_tuple_element_range<N>( r.begin(), r.end()))
 {
   return make_tuple_element_range<N>( std::forward<Range>(r).begin(),
                                       std::forward<Range>(r).end() );
@@ -28,7 +28,7 @@ inline constexpr bit::stl::tuple_element_range<0,Iterator,Sentinel>
 
 template<typename Range>
 inline constexpr auto bit::stl::make_key_range( Range&& r )
-  -> decltype(make_key_range( r.begin(), r.end()))
+  -> decltype(::bit::stl::make_key_range( r.begin(), r.end()))
 {
   return make_key_range<0>( std::forward<Range>(r).begin(),
                             std::forward<Range>(r).end() );
@@ -45,7 +45,7 @@ inline constexpr bit::stl::tuple_element_range<1,Iterator,Sentinel>
 
 template<typename Range>
 inline constexpr auto bit::stl::make_value_range( Range&& r )
-  -> decltype(make_value_range( r.begin(), r.end()))
+  -> decltype(::bit::stl::make_value_range( r.begin(), r.end()))
 {
   return make_value_range<1>( std::forward<Range>(r).begin(),
                               std::forward<Range>(r).end() );

--- a/include/bit/stl/ranges/move_range.hpp
+++ b/include/bit/stl/ranges/move_range.hpp
@@ -63,7 +63,10 @@ namespace bit {
     /// \return the type-deduced range
     template<typename Range>
     constexpr auto make_move_range( Range&& r )
-      -> decltype(::bit::stl::make_move_range( r.begin(), r.end() ));
+#ifndef _MSC_VER
+      -> decltype(::bit::stl::make_move_range( r.begin(), r.end() ))
+#endif // _MSC_VER
+    ;
 
   } // namespace stl
 } // namespace bit

--- a/include/bit/stl/ranges/move_range.hpp
+++ b/include/bit/stl/ranges/move_range.hpp
@@ -63,7 +63,7 @@ namespace bit {
     /// \return the type-deduced range
     template<typename Range>
     constexpr auto make_move_range( Range&& r )
-      -> decltype(make_move_range( r.begin(), r.end() ));
+      -> decltype(::bit::stl::make_move_range( r.begin(), r.end() ));
 
   } // namespace stl
 } // namespace bit

--- a/include/bit/stl/ranges/tuple_element_range.hpp
+++ b/include/bit/stl/ranges/tuple_element_range.hpp
@@ -67,7 +67,7 @@ namespace bit {
     /// \return the type-deduced tuple_element range
     template<std::size_t N, typename Range>
     constexpr auto make_tuple_element_range( Range&& r )
-      -> decltype(make_tuple_element_range<N>( r.begin(), r.end()));
+      -> decltype(::bit::stl::make_tuple_element_range<N>( r.begin(), r.end()));
 
 
     //-------------------------------------------------------------------------
@@ -88,7 +88,7 @@ namespace bit {
     /// \return a key range
     template<typename Range>
     constexpr auto make_key_range( Range&& r )
-      -> decltype(make_key_range( r.begin(), r.end()));
+      -> decltype(::bit::stl::make_key_range( r.begin(), r.end()));
 
     //-------------------------------------------------------------------------
 
@@ -108,7 +108,7 @@ namespace bit {
     /// \return a value range
     template<typename Range>
     constexpr auto make_value_range( Range&& r )
-      -> decltype(make_value_range( r.begin(), r.end()));
+      -> decltype(::bit::stl::make_value_range( r.begin(), r.end()));
 
   } // namespace stl
 } // namespace bit

--- a/include/bit/stl/ranges/tuple_element_range.hpp
+++ b/include/bit/stl/ranges/tuple_element_range.hpp
@@ -67,7 +67,10 @@ namespace bit {
     /// \return the type-deduced tuple_element range
     template<std::size_t N, typename Range>
     constexpr auto make_tuple_element_range( Range&& r )
-      -> decltype(::bit::stl::make_tuple_element_range<N>( r.begin(), r.end()));
+#ifndef _MSC_VER
+      -> decltype(::bit::stl::make_tuple_element_range<N>( r.begin(), r.end()))
+#endif // _MSC_VER
+    ;
 
 
     //-------------------------------------------------------------------------
@@ -88,7 +91,10 @@ namespace bit {
     /// \return a key range
     template<typename Range>
     constexpr auto make_key_range( Range&& r )
-      -> decltype(::bit::stl::make_key_range( r.begin(), r.end()));
+#ifndef _MSC_VER
+      -> decltype(::bit::stl::make_key_range( r.begin(), r.end()))
+#endif // _MSC_VER
+    ;
 
     //-------------------------------------------------------------------------
 
@@ -108,8 +114,10 @@ namespace bit {
     /// \return a value range
     template<typename Range>
     constexpr auto make_value_range( Range&& r )
-      -> decltype(::bit::stl::make_value_range( r.begin(), r.end()));
-
+#ifndef _MSC_VER
+      -> decltype(::bit::stl::make_value_range(r.begin(), r.end()))
+#endif // _MSC_VER
+    ;
   } // namespace stl
 } // namespace bit
 

--- a/include/bit/stl/utilities/compressed_pair.hpp
+++ b/include/bit/stl/utilities/compressed_pair.hpp
@@ -48,11 +48,12 @@
 #include "../traits/relationships/nth_type.hpp"
 
 #include <type_traits> // std::is_constructible, std::decay_t, etc...
-#include <tuple>       // std::get
 #include <utility>     // std::forward
 
 namespace bit {
   namespace stl {
+    template<typename,typename> class compressed_pair;
+
     namespace detail {
       template<typename T1,
                typename T2,
@@ -66,13 +67,14 @@ namespace bit {
       class compressed_pair_impl<T1,T1,true,true> : T1
       {
       public:
+
         template<typename U1, typename U2>
         constexpr compressed_pair_impl( U1&& u1, U2&& u2 ) : T1(std::forward<U1>(u1)), m_second(std::forward<U2>(u2)){}
 
         template<typename Tuple1, typename Tuple2, std::size_t...Idxs1, std::size_t...Idxs2>
         constexpr compressed_pair_impl( Tuple1&& tuple1, Tuple2&& tuple2, std::index_sequence<Idxs1...>, std::index_sequence<Idxs2...> )
-          : T1( std::get<Idxs1>( std::forward<Tuple1>(tuple1) )... ),
-            m_second( std::get<Idxs2>( std::forward<Tuple2>(tuple2) )... )
+          : T1( adl_get<Idxs1>( std::forward<Tuple1>(tuple1) )... ),
+            m_second( adl_get<Idxs2>( std::forward<Tuple2>(tuple2) )... )
         {
 
         }
@@ -97,8 +99,8 @@ namespace bit {
 
         template<typename Tuple1, typename Tuple2, std::size_t...Idxs1, std::size_t...Idxs2>
         constexpr compressed_pair_impl( Tuple1&& tuple1, Tuple2&& tuple2, std::index_sequence<Idxs1...>, std::index_sequence<Idxs2...> )
-          : T1( std::get<Idxs1>( std::forward<Tuple1>(tuple1) )... ),
-            T2( std::get<Idxs2>( std::forward<Tuple2>(tuple2) )... )
+        : T1( adl_get<Idxs1>( std::forward<Tuple1>(tuple1) )... ),
+          T2( adl_get<Idxs2>( std::forward<Tuple2>(tuple2) )... )
         {
 
         }
@@ -121,8 +123,8 @@ namespace bit {
 
         template<typename Tuple1, typename Tuple2, std::size_t...Idxs1, std::size_t...Idxs2>
         constexpr compressed_pair_impl( Tuple1&& tuple1, Tuple2&& tuple2, std::index_sequence<Idxs1...>, std::index_sequence<Idxs2...> )
-          : T1( std::get<Idxs1>( std::forward<Tuple1>(tuple1) )... ),
-            m_second( std::get<Idxs2>( std::forward<Tuple2>(tuple2) )... )
+          : T1( adl_get<Idxs1>( std::forward<Tuple1>(tuple1) )... ),
+            m_second( adl_get<Idxs2>( std::forward<Tuple2>(tuple2) )... )
         {
 
         }
@@ -152,8 +154,8 @@ namespace bit {
 
         template<typename Tuple1, typename Tuple2, std::size_t...Idxs1, std::size_t...Idxs2>
         constexpr compressed_pair_impl( Tuple1&& tuple1, Tuple2&& tuple2, std::index_sequence<Idxs1...>, std::index_sequence<Idxs2...> )
-          : T2( std::get<Idxs2>( std::forward<Tuple2>(tuple2) )... ),
-            m_first( std::get<Idxs1>( std::forward<Tuple1>(tuple1) )... )
+          : T2( adl_get<Idxs2>( std::forward<Tuple2>(tuple2) )... ),
+            m_first( adl_get<Idxs1>( std::forward<Tuple1>(tuple1) )... )
         {
 
         }
@@ -182,9 +184,9 @@ namespace bit {
         constexpr compressed_pair_impl( U1&& u1, U2&& u2 ) : m_first(std::forward<U1>(u1)), m_second(std::forward<U2>(u2)){}
 
         template<typename Tuple1, typename Tuple2, std::size_t...Idxs1, std::size_t...Idxs2>
-        constexpr compressed_pair_impl( Tuple1 tuple1, Tuple2 tuple2, std::index_sequence<Idxs1...>, std::index_sequence<Idxs2...> )
-          : m_first( std::get<Idxs1>(tuple1)... ),
-            m_second( std::get<Idxs2>(tuple2)... )
+        constexpr compressed_pair_impl( Tuple1&& tuple1, Tuple2&& tuple2, std::index_sequence<Idxs1...>, std::index_sequence<Idxs2...> )
+          : m_first( adl_get<Idxs1>( std::forward<Tuple1>(tuple1) )... ),
+            m_second( adl_get<Idxs2>( std::forward<Tuple2>(tuple2) )... )
         {
 
         }

--- a/include/bit/stl/utilities/detail/compressed_tuple.inl
+++ b/include/bit/stl/utilities/detail/compressed_tuple.inl
@@ -15,7 +15,7 @@ inline constexpr bit::stl::detail::compressed_tuple_storage<Idx,T,true>
   ::compressed_tuple_storage( std::piecewise_construct_t,
                               Tuple&& tuple,
                               std::index_sequence<Idxs...> )
-  : T( get<Idxs>(tuple)... )
+  : T( adl_get<Idxs>( std::forward<Tuple>(tuple) )... )
 {
 
 }
@@ -84,7 +84,7 @@ inline constexpr bit::stl::detail::compressed_tuple_storage<Idx,T,false>
   ::compressed_tuple_storage( std::piecewise_construct_t,
                               Tuple&& tuple,
                               std::index_sequence<Idxs...> )
-    : m_current( get<Idxs>(tuple)... )
+    : m_current( adl_get<Idxs>( std::forward<Tuple>(tuple) )... )
 {
 
 }
@@ -385,7 +385,7 @@ template<typename...Types>
 template<typename Tuple, std::size_t...Idxs>
 inline constexpr bit::stl::compressed_tuple<Types...>
   ::compressed_tuple( std::index_sequence<Idxs...>, Tuple&& tuple )
-  : base_type( in_place, get<Idxs>( std::forward<Tuple>(tuple) )... )
+  : base_type( in_place, adl_get<Idxs>( std::forward<Tuple>(tuple) )... )
 {
 
 }
@@ -399,7 +399,7 @@ template<typename Tuple, std::size_t...Idxs>
 inline void bit::stl::compressed_tuple<Types...>
   ::assign_tuple( std::index_sequence<Idxs...>, Tuple&& tuple )
 {
-  base_type::assign( get<Idxs>( std::forward<Tuple>(tuple) )... );
+  base_type::assign( adl_get<Idxs>( std::forward<Tuple>(tuple) )... );
 }
 
 

--- a/include/bit/stl/utilities/detail/tuple_utilities.inl
+++ b/include/bit/stl/utilities/detail/tuple_utilities.inl
@@ -1,25 +1,58 @@
 #ifndef BIT_STL_UTILITIES_DETAIL_TUPLE_UTILITIES_INL
 #define BIT_STL_UTILITIES_DETAIL_TUPLE_UTILITIES_INL
 
-namespace bit {
-  namespace stl {
-    namespace detail {
+namespace bit { namespace stl { namespace detail {
+  template<typename T>
+  struct adl_get_protector { static constexpr bool stop = false; };
+} } } // namespace bit::stl::detail
 
-      template<typename Func, typename Tuple, size_t...Idxs>
-      constexpr decltype(auto) apply_impl( Func&& func, Tuple&& tuple, std::index_sequence<Idxs...> )
-      {
-        return invoke( std::forward<Func>(func), get<Idxs>(std::forward<Tuple>(tuple))... );
-      }
+template<typename T, typename Tuple>
+inline void bit::stl::adl::get( Tuple&& )
+{
+  static_assert( detail::adl_get_protector<Tuple>::stop,
+                 "adl::get must not be used" );
+}
 
-      template<typename T, typename Tuple, size_t...Idxs>
-      constexpr T make_from_tuple( Tuple&& tuple, std::index_sequence<Idxs...> )
-      {
-        return T( get<Idxs>(std::forward<Tuple>(tuple))...);
-      }
+template<std::size_t, typename Tuple>
+inline void bit::stl::adl::get( Tuple&& )
+{
+  static_assert( detail::adl_get_protector<Tuple>::stop,
+                 "adl::get must not be used" );
+}
 
-    } // namespace detail
-  } // namespace stl
-} // namespace bit
+template<std::size_t Idx, typename Tuple>
+decltype(auto) bit::stl::adl_get( Tuple&& tuple )
+{
+  using ::bit::stl::adl::get;
+
+  return get<Idx>( std::forward<Tuple>(tuple) );
+}
+
+template<typename T, typename Tuple>
+decltype(auto) bit::stl::adl_get( Tuple&& tuple )
+{
+  using ::bit::stl::adl::get;
+
+  return get<T>( std::forward<Tuple>(tuple) );
+}
+
+namespace bit { namespace stl { namespace detail {
+  template<typename Func, typename Tuple, size_t...Idxs>
+  constexpr decltype(auto) apply_impl( Func&& func, Tuple&& tuple, std::index_sequence<Idxs...> )
+  {
+    using ::bit::stl::adl::get;
+
+    return invoke( std::forward<Func>(func), get<Idxs>(std::forward<Tuple>(tuple))... );
+  }
+
+  template<typename T, typename Tuple, size_t...Idxs>
+  constexpr T make_from_tuple( Tuple&& tuple, std::index_sequence<Idxs...> )
+  {
+    using ::bit::stl::adl::get;
+
+    return T( get<Idxs>(std::forward<Tuple>(tuple))...);
+  }
+} } } // namespace bit::stl::detail
 
 template<typename Func, typename Tuple>
 constexpr decltype(auto) bit::stl::apply( Func&& function, Tuple&& tuple )

--- a/include/bit/stl/utilities/detail/uninitialized_storage.inl
+++ b/include/bit/stl/utilities/detail/uninitialized_storage.inl
@@ -38,7 +38,9 @@ namespace bit { namespace stl { namespace detail {
 template <typename T, typename Tuple, std::size_t... I>
 inline T* uninitialized_tuple_construct_at_impl( void* ptr, Tuple&& t, std::index_sequence<I...> )
 {
-  new (ptr) T(std::get<I>(std::forward<Tuple>(t))...);
+  using ::bit::stl::adl::get;
+
+  new (ptr) T(get<I>(std::forward<Tuple>(t))...);
   return static_cast<T*>(ptr);
 }
 

--- a/include/bit/stl/utilities/tuple_utilities.hpp
+++ b/include/bit/stl/utilities/tuple_utilities.hpp
@@ -40,7 +40,9 @@
 # pragma once
 #endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
 
+#include "invoke.hpp"  // invoke
 #include "types.hpp"   // size_t
+
 #include <type_traits> // std::decay
 #include <utility>     // std::forward, std::index_sequence
 
@@ -72,22 +74,21 @@ namespace bit {
     // This exists so that ADL-lookup can be done with 'get' from different
     // namespaces, if they are so provided for types. This allows std::get to
     // function independently from bit::stl::get
-    template<size_t I, typename Tuple>
-    tuple_element_t<I,std::decay_t<Tuple>>& get( Tuple& t );
-    template<size_t I, typename Tuple>
-    const tuple_element_t<I,std::decay_t<Tuple>>& get( const Tuple& t );
-    template<size_t I, typename Tuple>
-    tuple_element_t<I,std::decay_t<Tuple>>&& get( Tuple&& t );
-    template<size_t I, typename Tuple>
-    const tuple_element_t<I,std::decay_t<Tuple>>&& get( const Tuple&& t );
+    namespace adl {
+
+      template<typename T, typename Tuple>
+      void get( Tuple&& );
+
+      template<std::size_t, typename Tuple>
+      void get( Tuple&& );
+
+    } // namespace adl
+
+    template<std::size_t Idx, typename Tuple>
+    decltype(auto) adl_get( Tuple&& tuple );
+
     template<typename T, typename Tuple>
-    T& get( Tuple& t );
-    template<typename T, typename Tuple>
-    const T& get( const Tuple& t );
-    template<typename T, typename Tuple>
-    T&& get( Tuple&& t );
-    template<typename T, typename Tuple>
-    const T&& get( const Tuple&& t );
+    decltype(auto) adl_get( Tuple&& tuple );
 
     //-------------------------------------------------------------------------
 

--- a/include/bit/stl/utilities/types.hpp
+++ b/include/bit/stl/utilities/types.hpp
@@ -65,6 +65,28 @@ namespace bit {
     /// \c operator"" overloads in this namespace
     inline namespace literals{} // namespace literals
 
+    /// \brief Namespace for managing functions template for forward
+    ///        declarations
+    ///
+    /// This contains function templates that don't contain definitions
+    /// that can be used with a using statement/directive to allow for
+    /// determining ADL functions unqualified
+    ///
+    /// An example use of this is below:
+    ///
+    /// \code
+    /// template<typename T, typename Tuple,std::size_t...Idxs>
+    /// T make_from_tuple( Tuple&& tuple )
+    /// {
+    ///   using namespace bit::stl::adl;
+    ///   // or using bit::stl::adl::get
+    ///
+    ///   // adl-picks 'get<I> for appropriate 'Tuple' type
+    ///   return T( get<Idxs>( std::forward<Tuple>(tuple) )... );
+    /// }
+    /// \endcode
+    namespace adl{};
+
     /// \brief Private namespace for managing implementation-details within
     ///        headers
     ///

--- a/include/bit/stl/utilities/types.hpp
+++ b/include/bit/stl/utilities/types.hpp
@@ -85,7 +85,7 @@ namespace bit {
     ///   return T( get<Idxs>( std::forward<Tuple>(tuple) )... );
     /// }
     /// \endcode
-    namespace adl{};
+    namespace adl{}
 
     /// \brief Private namespace for managing implementation-details within
     ///        headers

--- a/include/bit/stl/utilities/uninitialized_storage.hpp
+++ b/include/bit/stl/utilities/uninitialized_storage.hpp
@@ -36,6 +36,8 @@
 # pragma once
 #endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
 
+#include "tuple_utilities.hpp"
+
 #include <iterator> // std::iterator_traits
 #include <new>      // placement new
 #include <memory>   // std::addressof


### PR DESCRIPTION
### Objectives:

* **Add adl namespace documentation to types**
This new namespace is used for adl-functions that don't have 
definitions. Bringing these functions in allow dispatching via
ADL to appropriate functions.

* **Add adl::get utility**
This adds an adl overload for get<Idx> and get<T> for tuples. 
This simplifies tuple uses without requiring pulling in <tuple>,
<pair>, etc for a definition

* **Use adl::get utility**
All existing uses of "std::get" have been changed to use the adl
get instead