### PR TITLE
Fix optional or_else monad function

### DIFF
--- a/include/bit/stl/utilities/detail/optional.inl
+++ b/include/bit/stl/utilities/detail/optional.inl
@@ -311,7 +311,7 @@ template<typename U>
 bit::stl::optional<std::decay_t<U>> bit::stl::optional<T>::or_else( U&& u )
   const
 {
-  if( has_value() ) return make_optional( std::forward<U>(u) );
+  if( !has_value() ) return make_optional( std::forward<U>(u) );
   return nullopt;
 }
 


### PR DESCRIPTION
A bug in the previous PR results in `or_else` functioning identically 
to `and_then`. 