### PR TITLE
Split byte into inl file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ option(BIT_STL_COMPILE_UNIT_TESTS "Compile and run the unit tests for this libra
 option(BIT_STL_GENERATE_DOCUMENTATION "Generates doxygen documentation" off)
 option(BIT_STL_VERBOSE_CONFIGURE "Verbosely configures this library project" off)
 
-project("BitStl")
+project("BitStl" LANGUAGES CXX)
 
 #-----------------------------------------------------------------------------
 # Version Info
@@ -177,6 +177,7 @@ set(headers
   # utilities
   include/bit/stl/utilities/aligned_storage.hpp
   include/bit/stl/utilities/assert.hpp
+  include/bit/stl/utilities/byte.hpp
   include/bit/stl/utilities/casts.hpp
   include/bit/stl/utilities/compressed_pair.hpp
   include/bit/stl/utilities/compressed_tuple.hpp

--- a/include/bit/stl/utilities/byte.hpp
+++ b/include/bit/stl/utilities/byte.hpp
@@ -42,6 +42,10 @@
 namespace bit {
   namespace stl {
 
+    //=========================================================================
+    // enum class : byte
+    //=========================================================================
+
     /// \brief Unsigned byte type
     ///
     /// \note Due to a restriction in pre-C++-17, a conversion to a pointer of
@@ -49,8 +53,12 @@ namespace bit {
     ///       strict-aliasing.
     enum class byte : unsigned char{};
 
+    //=========================================================================
+    // non-member operators : enum class : byte
+    //=========================================================================
+
     //-------------------------------------------------------------------------
-    // Byte Operators
+    // Operators
     //-------------------------------------------------------------------------
 
 #ifndef BIT_DOXYGEN_BUILD
@@ -58,87 +66,45 @@ namespace bit {
 #else
     template<typename IntT>
 #endif
-    inline constexpr byte& operator<<=(byte& lhs, IntT shift)
-      noexcept
-    {
-        return lhs = byte(static_cast<unsigned char>(lhs) << shift);
-    }
+    constexpr byte operator<<( byte lhs, IntT shift ) noexcept;
 
 #ifndef BIT_DOXYGEN_BUILD
     template<typename IntT, typename = std::enable_if_t<std::is_integral<IntT>::value>>
 #else
     template<typename IntT>
 #endif
-    inline constexpr byte operator<<(byte lhs, IntT shift)
-      noexcept
-    {
-        return byte(static_cast<unsigned char>(lhs) << shift);
-    }
+    constexpr byte operator>>( byte lhs, IntT shift ) noexcept;
+
+    constexpr byte operator|( byte lhs, byte rhs ) noexcept;
+    constexpr byte operator&( byte lhs, byte rhs ) noexcept;
+    constexpr byte operator^( byte lhs, byte rhs ) noexcept;
+    constexpr byte operator~( byte lhs ) noexcept;
+
+    //-------------------------------------------------------------------------
+    // Compound Assignment Operators
+    //-------------------------------------------------------------------------
 
 #ifndef BIT_DOXYGEN_BUILD
     template<typename IntT, typename = std::enable_if_t<std::is_integral<IntT>::value>>
 #else
     template<typename IntT>
 #endif
-    inline constexpr byte& operator>>=(byte& lhs, IntT shift)
-      noexcept
-    {
-        return lhs = byte(static_cast<unsigned char>(lhs) >> shift);
-    }
+    constexpr byte& operator<<=( byte& lhs, IntT shift ) noexcept;
 
 #ifndef BIT_DOXYGEN_BUILD
     template<typename IntT, typename = std::enable_if_t<std::is_integral<IntT>::value>>
 #else
     template<typename IntT>
 #endif
-    inline constexpr byte operator>>(byte lhs, IntT shift)
-      noexcept
-    {
-        return byte(static_cast<unsigned char>(lhs) >> shift);
-    }
+    constexpr byte& operator>>=( byte& lhs, IntT shift ) noexcept;
 
-    inline byte& operator|=(byte& lhs, byte rhs)
-      noexcept
-    {
-        return lhs = byte(static_cast<unsigned char>(lhs) | static_cast<unsigned char>(rhs));
-    }
 
-    inline constexpr byte operator|(byte lhs, byte rhs)
-      noexcept
-    {
-        return byte(static_cast<unsigned char>(lhs) | static_cast<unsigned char>(rhs));
-    }
-
-    inline byte& operator&=(byte& lhs, byte rhs)
-      noexcept
-    {
-        return lhs = byte(static_cast<unsigned char>(lhs) & static_cast<unsigned char>(rhs));
-    }
-
-    inline constexpr byte operator&(byte lhs, byte rhs)
-      noexcept
-    {
-        return byte(static_cast<unsigned char>(lhs) & static_cast<unsigned char>(rhs));
-    }
-
-    inline byte& operator^=(byte& lhs, byte rhs)
-      noexcept
-    {
-        return lhs = byte(static_cast<unsigned char>(lhs) ^ static_cast<unsigned char>(rhs));
-    }
-
-    inline constexpr byte operator^(byte lhs, byte rhs)
-      noexcept
-    {
-        return byte(static_cast<unsigned char>(lhs) ^ static_cast<unsigned char>(rhs));
-    }
-
-    inline constexpr byte operator~(byte lhs)
-      noexcept
-    {
-      return byte(~static_cast<unsigned char>(lhs));
-    }
+    byte& operator|=( byte& lhs, byte rhs ) noexcept;
+    byte& operator^=( byte& lhs, byte rhs ) noexcept;
+    byte& operator&=( byte& lhs, byte rhs ) noexcept;
   } // namespace stl
 } // namespace bit
+
+#include "detail/byte.inl"
 
 #endif /* BIT_STL_UTILITIES_BYTE_HPP */

--- a/include/bit/stl/utilities/detail/byte.inl
+++ b/include/bit/stl/utilities/detail/byte.inl
@@ -1,0 +1,92 @@
+#ifndef BIT_STL_UTILITIES_DETAIL_BYTE_INL
+#define BIT_STL_UTILITIES_DETAIL_BYTE_INL
+
+//=============================================================================
+// definitions : non-member operators : enum class : byte
+//=============================================================================
+
+//-----------------------------------------------------------------------------
+// Operators
+//-----------------------------------------------------------------------------
+
+template<typename IntT, typename>
+inline constexpr bit::stl::byte bit::stl::operator<<( byte lhs, IntT shift )
+  noexcept
+{
+  return byte(static_cast<unsigned char>(lhs) << shift);
+}
+
+template<typename IntT, typename>
+inline constexpr bit::stl::byte bit::stl::operator>>( byte lhs, IntT shift )
+  noexcept
+{
+  return byte(static_cast<unsigned char>(lhs) >> shift);
+}
+
+//-----------------------------------------------------------------------------
+
+inline constexpr bit::stl::byte bit::stl::operator|( byte lhs, byte rhs )
+  noexcept
+{
+  return byte(static_cast<unsigned char>(lhs) | static_cast<unsigned char>(rhs));
+}
+
+inline constexpr bit::stl::byte bit::stl::operator&( byte lhs, byte rhs )
+  noexcept
+{
+  return byte(static_cast<unsigned char>(lhs) & static_cast<unsigned char>(rhs));
+}
+
+inline constexpr bit::stl::byte bit::stl::operator^( byte lhs, byte rhs )
+  noexcept
+{
+  return byte(static_cast<unsigned char>(lhs) ^ static_cast<unsigned char>(rhs));
+}
+
+//-----------------------------------------------------------------------------
+
+inline constexpr bit::stl::byte bit::stl::operator~( byte lhs )
+  noexcept
+{
+  return byte(~static_cast<unsigned char>(lhs));
+}
+
+//-----------------------------------------------------------------------------
+// Compound Assignment Operators
+//-----------------------------------------------------------------------------
+
+template<typename IntT, typename>
+inline constexpr bit::stl::byte& bit::stl::operator<<=( byte& lhs, IntT shift )
+  noexcept
+{
+  return lhs = byte(static_cast<unsigned char>(lhs) << shift);
+}
+
+template<typename IntT, typename>
+inline constexpr bit::stl::byte& bit::stl::operator>>=( byte& lhs, IntT shift )
+  noexcept
+{
+  return lhs = byte(static_cast<unsigned char>(lhs) >> shift);
+}
+
+//-----------------------------------------------------------------------------
+
+inline bit::stl::byte& bit::stl::operator|=( byte& lhs, byte rhs )
+  noexcept
+{
+  return lhs = byte(static_cast<unsigned char>(lhs) | static_cast<unsigned char>(rhs));
+}
+
+inline bit::stl::byte& bit::stl::operator&=( byte& lhs, byte rhs )
+  noexcept
+{
+  return lhs = byte(static_cast<unsigned char>(lhs) & static_cast<unsigned char>(rhs));
+}
+
+inline bit::stl::byte& bit::stl::operator^=( byte& lhs, byte rhs )
+  noexcept
+{
+  return lhs = byte(static_cast<unsigned char>(lhs) ^ static_cast<unsigned char>(rhs));
+}
+
+#endif /* BIT_STL_UTILITIES_DETAIL_BYTE_INL */


### PR DESCRIPTION
This splits the `byte.hpp` into a separate `byte.inl` for definitions